### PR TITLE
Bruk riktig bucket mot dokument

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/FamilieVedleggClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/FamilieVedleggClient.kt
@@ -21,7 +21,7 @@ class FamilieVedleggClient(
 
     private val hentVedleggUri = UriComponentsBuilder.fromUri(dokumentApiURI)
         .path(HENT)
-        .pathSegment("{id}")
+        .pathSegment("{id}", "pdf")
         .encode().toUriString()
 
     fun hentVedlegg(vedleggId: UUID): ByteArray {

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/FamilieVedleggClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/FamilieVedleggClient.kt
@@ -30,7 +30,7 @@ class FamilieVedleggClient(
 
     companion object {
 
-        private const val HENT = "api/mapper/familievedlegg/"
+        private const val HENT = "api/mapper/tilleggsstonad"
         private val HENT_HEADERS = HttpHeaders().apply {
             accept = listOf(MediaType.APPLICATION_OCTET_STREAM)
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Frontend bruker `tilleggsstonad` ved lagring av vedlegg

https://github.com/navikt/tilleggsstonader-soknad/blob/main/src/backend/milj%C3%B8.ts#L11

søknad-api må bruke den samme vid henting av dokument