### PR TITLE
Henter mapping fra kodeverk

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -62,6 +62,7 @@ spec:
           namespace: teamfamilie
       external:
         - host: pdl-api-q1.dev-fss-pub.nais.io
+        - host: kodeverk-api.nav.no
   tokenx:
     enabled: true
   azure:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -59,6 +59,8 @@ spec:
         - application: tilleggsstonader-integrasjoner
         - application: tilleggsstonader-htmlify
         - application: tilleggsstonader-sak
+        - application: kodeverk-api
+          namespace: team-rocket
       external:
         - host: pdl-api.prod-fss-pub.nais.io
   tokenx:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 val javaVersion = JavaLanguageVersion.of(21)
 val tilleggsstønaderLibsVersion = "2024.02.12-15.54.60684ccdf789"
-val tilleggsstønaderKontrakterVersion = "2024.02.19-09.20.56054405804e"
+val tilleggsstønaderKontrakterVersion = "2024.02.27-14.23.0a408b63334a"
 val familieProsesseringVersion = "2.20240110093731_0eda75e"
 val tokenSupportVersion = "4.1.3"
 val wiremockVersion = "3.0.1"

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/config/CacheConfig.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/config/CacheConfig.kt
@@ -1,0 +1,27 @@
+package no.nav.tilleggsstonader.soknad.infrastruktur.config
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.concurrent.ConcurrentMapCache
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.TimeUnit
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean("kodeverkCache")
+    fun kodeverkCache(): CacheManager = object : ConcurrentMapCacheManager() {
+        override fun createConcurrentMapCache(name: String): Cache {
+            val concurrentMap = Caffeine
+                .newBuilder()
+                .maximumSize(1000)
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .recordStats().build<Any, Any>().asMap()
+            return ConcurrentMapCache(name, concurrentMap, true)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkClient.kt
@@ -22,7 +22,7 @@ class KodeverkClient(
 
     private val kodeverkUri = UriComponentsBuilder.fromUri(uri)
         .pathSegment("api", "v1", "kodeverk", "{kodeverksnavn}", "koder", "betydninger")
-        .queryParam("ekskluderUgyldige", "false") // henter historikk
+        .queryParam("ekskluderUgyldige", "true") // henter ikke historikk
         .queryParam("spraak", "nb")
         .encode()
         .toUriString()

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkClient.kt
@@ -1,0 +1,29 @@
+package no.nav.tilleggsstonader.soknad.kodeverk
+
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Component
+class KodeverkClient(
+    @Value("\${clients.kodeverk.uri}")
+    private val uri: URI,
+    @Qualifier("azureClientCredential") restTemplate: RestTemplate,
+) :
+    AbstractRestClient(restTemplate) {
+
+    fun hentPostnummer(): KodeverkDto =
+        getForEntity(kodeverkUri, null, mapOf("kodeverksnavn" to "Postnummer"))
+
+    private val kodeverkUri = UriComponentsBuilder.fromUri(uri)
+        .pathSegment("api", "v1", "kodeverk", "{kodeverksnavn}", "koder", "betydninger")
+        .queryParam("ekskluderUgyldige", "false") // henter historikk
+        .queryParam("spraak", "nb")
+        .encode()
+        .toUriString()
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
@@ -1,0 +1,59 @@
+package no.nav.tilleggsstonader.soknad.kodeverk
+
+import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.cache.CacheManager
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Henter kodeverk på nytt hver natt kl 1. Dette for å unngå at vi må hente det synkront når noen trenger dataen.
+ * Disse blir cachet i [CachedKodeverkService]
+ */
+@Component
+@Profile("!local & !integrasjonstest")
+class KodeverkInitializer(
+    private val kodeverkService: CachedKodeverkService,
+    @Qualifier("kodeverkCache")
+    private val cacheManager: CacheManager,
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Scheduled(cron = HVER_DAG_KL_01)
+    fun syncKodeverk() {
+        logger.info("Kjører schedulert jobb for å hente kodeverk")
+        cacheManager.cacheNames.stream().forEach { cacheManager.getCache(it)?.clear() }
+        sync()
+    }
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+        sync()
+    }
+
+    private fun sync() {
+        syncKodeverk("Postnummer", kodeverkService::hentPoststed)
+    }
+
+    private fun syncKodeverk(navn: String, henter: () -> Unit) {
+        try {
+            MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
+            logger.info("Henter $navn")
+            henter.invoke()
+        } catch (e: Exception) {
+            logger.warn("Feilet henting av $navn ${e.message}")
+        } finally {
+            MDC.clear()
+        }
+    }
+
+    companion object {
+        private const val HVER_DAG_KL_01 = "0 0 1 * * *"
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  * Disse blir cachet i [CachedKodeverkService]
  */
 @Component
-@Profile("!local & !integrasjonstest")
+@Profile("!integrasjonstest")
 class KodeverkInitializer(
     private val kodeverkService: CachedKodeverkService,
     @Qualifier("kodeverkCache")

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
@@ -1,0 +1,53 @@
+package no.nav.tilleggsstonader.soknad.kodeverk
+
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.hentGjeldende
+import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * Henter cachade verdier fra kodeverk. Kodeverk inneholder mapping av div verdier til norsk tekst av verdiet.
+ * Eks inneholder kodeverk mapping fra postnummer 0010 til Oslo
+ */
+@Service
+class KodeverkService(
+    private val cachedKodeverkService: CachedKodeverkService,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    fun hentPoststed(postnummer: String?) = hentKodeverdi("poststed", postnummer) {
+        cachedKodeverkService.hentPoststed().hentGjeldende(it)
+    }
+
+    private fun hentKodeverdi(type: String, kode: String?, hentKodeverdiFunction: Function1<String, String?>): String {
+        return try {
+            kode?.let(hentKodeverdiFunction) ?: kode ?: ""
+        } catch (e: Exception) {
+            // Ikke la feil kodeverk stoppe henting av data
+            logger.error("Feilet henting av $type til $kode message=${e.message} cause=${e.cause?.message}")
+            ""
+        }
+    }
+}
+
+@Service
+@CacheConfig(cacheManager = "kodeverkCache")
+class CachedKodeverkService(
+    private val kodeverkClient: KodeverkClient,
+) {
+    @Cacheable("kodeverk_postestedMedHistorikk", sync = true)
+    fun hentPoststed(): KodeverkDto = kodeverkClient.hentPostnummer()
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
@@ -2,21 +2,10 @@ package no.nav.tilleggsstonader.soknad.kodeverk
 
 import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
 import no.nav.tilleggsstonader.kontrakter.kodeverk.hentGjeldende
-import no.nav.tilleggsstonader.libs.log.mdc.MDCConstants
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
-import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.context.event.ApplicationReadyEvent
-import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
-import org.springframework.context.ApplicationListener
-import org.springframework.context.annotation.Profile
-import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
-import java.time.LocalDate
-import java.util.UUID
 
 /**
  * Henter cachade verdier fra kodeverk. Kodeverk inneholder mapping av div verdier til norsk tekst av verdiet.

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,3 +8,5 @@ clients:
     uri: https://pdl-api-q1.dev-fss-pub.nais.io
     audience: dev-fss:pdl:pdl-api-q1
     scope: api://dev-fss.pdl.pdl-api-q1/.default
+  kodeverk:
+    uri: https://kodeverk-api.nav.no

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,6 +131,16 @@ no.nav.security.jwt:
         client-secret: ${AZURE_APP_CLIENT_SECRET}
         client-auth-method: client_secret_basic
 
+    kodeverk-client_credentials:
+      resource-url: ${clients.kodeverk.uri}
+      token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
+      grant-type: client_credentials
+      scope: ${clients.kodeverk.scope}
+      authentication:
+        client-id: ${AZURE_APP_CLIENT_ID}
+        client-secret: ${AZURE_APP_CLIENT_SECRET}
+        client-auth-method: client_secret_basic
+
     sak-client_credentials:
       resource-url: ${clients.sak.uri}
       token-endpoint-url: ${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT}
@@ -160,5 +170,8 @@ clients:
   htmlify:
     uri: http://tilleggsstonader-htmlify
     scope: api://${CLIENT_ENV}-gcp.tilleggsstonader.tilleggsstonader-htmlify/.default
+  kodeverk:
+    uri: http://kodeverk-api.team-rocket
+    scope: api://${CLIENT_ENV}-gcp.team-rocket.kodeverk-api/.default
 
 KAFKA_TOPIC_DITTNAV: min-side.aapen-brukervarsel-v1

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/IntegrationTest.kt
@@ -46,6 +46,7 @@ class DefaultRestTemplateConfiguration {
     "mock-pdl",
     "mock-sak",
     "mock-vedlegg",
+    "mock-kodeverk",
 )
 @EnableMockOAuth2Server
 abstract class IntegrationTest {

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/SøknadApiLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/SøknadApiLocal.kt
@@ -21,6 +21,7 @@ fun main(args: Array<String>) {
             "mock-vedlegg",
             "mock-sak",
             "mock-familie-vedlegg-controller",
+            "mock-kodeverk",
         )
         .properties(mapOf("mock-oauth2-server.port" to mockOauth2ServerPort))
         .run(*args)

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/KodeverkClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/KodeverkClientConfig.kt
@@ -1,0 +1,34 @@
+package no.nav.tilleggsstonader.soknad.infrastruktur
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.kontrakter.kodeverk.BeskrivelseDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.BetydningDto
+import no.nav.tilleggsstonader.kontrakter.kodeverk.KodeverkDto
+import no.nav.tilleggsstonader.soknad.kodeverk.KodeverkClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import java.time.LocalDate
+
+@Configuration
+@Profile("mock-kodeverk")
+class KodeverkClientConfig {
+
+    @Bean
+    fun kodeverkClient(): KodeverkClient {
+        val client = mockk<KodeverkClient>()
+        every { client.hentPostnummer() } returns KodeverkDto(
+            mapOf(
+                "Postnummer" to listOf(
+                    BetydningDto(
+                        LocalDate.now(),
+                        LocalDate.now(),
+                        mapOf("nb" to BeskrivelseDto("0010", "Oslo")),
+                    ),
+                ),
+            ),
+        )
+        return client
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Henter kodeverk for å kunne mappe postkode til poststed til adressefeltet

Både dev og prod skal gå mot prod.
I dev må vi bruke .nav.no adresse for å kunne kalle på tjenesten då service discovery/intern.nav.no ikke er tilgjengelig fra dev.