### PR TITLE
Fjerner telenr, epost og kontonr som ikke skal vises i søknaden

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/person/PersonService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/person/PersonService.kt
@@ -10,7 +10,6 @@ import no.nav.tilleggsstonader.soknad.person.pdl.dto.Familierelasjonsrolle
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.PdlBarn
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.PdlSøker
 import no.nav.tilleggsstonader.soknad.person.pdl.erStrengtFortrolig
-import no.nav.tilleggsstonader.soknad.util.EnvUtil
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.Period
@@ -30,18 +29,11 @@ class PersonService(
         if (søkerEllerBarnErGradert(søker, barn)) {
             throw GradertBrukerException()
         }
-        // TODO fjern mockdata
-        if (EnvUtil.erIProd()) {
-            error("Fikse mocket data")
-        }
 
         return PersonMedBarnDto(
             fornavn = søker.navn.first().fornavn,
             visningsnavn = søker.navn.first().visningsnavn(),
             adresse = adresseMapper.tilFormatertAdresse(søker),
-            telefonnr = "950863265",
-            epost = "mail@gmail.com",
-            kontonr = "1234.56.78910",
             barn = mapBarn(barn),
         )
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/person/dto/PersonMedBarnDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/person/dto/PersonMedBarnDto.kt
@@ -6,9 +6,6 @@ data class PersonMedBarnDto(
     val fornavn: String,
     val visningsnavn: String,
     val adresse: String,
-    val telefonnr: String,
-    val epost: String,
-    val kontonr: String,
     val barn: List<Barn>,
 )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/PdlClientConfig.kt
@@ -14,6 +14,7 @@ import no.nav.tilleggsstonader.soknad.person.pdl.dto.Fødsel
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.Navn
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.PdlBarn
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.PdlSøker
+import no.nav.tilleggsstonader.soknad.person.pdl.dto.Vegadresse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -68,7 +69,7 @@ fun navn(
 
 fun lagPdlSøker(
     adressebeskyttelse: AdressebeskyttelseGradering = AdressebeskyttelseGradering.UGRADERT,
-    bostedsadresse: Bostedsadresse = Bostedsadresse(null, null),
+    bostedsadresse: Bostedsadresse = Bostedsadresse(vegadresse(), null),
     forelderBarnRelasjon: List<ForelderBarnRelasjon> = emptyList(),
     navn: Navn = navn(),
 ) = PdlSøker(
@@ -76,6 +77,14 @@ fun lagPdlSøker(
     bostedsadresse = listOf(bostedsadresse),
     forelderBarnRelasjon = forelderBarnRelasjon,
     navn = listOf(navn),
+)
+
+private fun vegadresse() = Vegadresse(
+    husnummer = "3",
+    husbokstav = "a",
+    bruksenhetsnummer = null,
+    adressenavn = "Hildes vei",
+    postnummer = "0100",
 )
 
 fun lagPdlBarn(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har fjernet personalia i frontend, trenger ikke disse feltene
Lagt til en "adresse" for å kunne vise i frontend

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-19945

Koblet til
* https://github.com/navikt/tilleggsstonader-soknad/pull/248