### PR TITLE
🐛 Må ha navn på cacheable, hvis ikke feiler hentingen fra cache

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
@@ -44,11 +44,11 @@ class KodeverkInitializer(
     private fun syncKodeverk(navn: String, henter: () -> Unit) {
         try {
             MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
-            logger.info("Henter $navn")
+            logger.info("Henter kodeverk=$navn")
             henter.invoke()
-            logger.info("Hentet $navn")
+            logger.info("Hentet kodeverk=$navn")
         } catch (e: Exception) {
-            logger.warn("Feilet synk av $navn ${e.message}")
+            logger.warn("Feilet synk av kodeverk=$navn ${e.message}")
         } finally {
             MDC.clear()
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkInitializer.kt
@@ -38,7 +38,7 @@ class KodeverkInitializer(
     }
 
     private fun sync() {
-        syncKodeverk("Postnummer", kodeverkService::hentPoststed)
+        syncKodeverk("Poststed", kodeverkService::hentPoststed)
     }
 
     private fun syncKodeverk(navn: String, henter: () -> Unit) {
@@ -46,8 +46,9 @@ class KodeverkInitializer(
             MDC.put(MDCConstants.MDC_CALL_ID, UUID.randomUUID().toString())
             logger.info("Henter $navn")
             henter.invoke()
+            logger.info("Hentet $navn")
         } catch (e: Exception) {
-            logger.warn("Feilet henting av $navn ${e.message}")
+            logger.warn("Feilet synk av $navn ${e.message}")
         } finally {
             MDC.clear()
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/KodeverkService.kt
@@ -37,6 +37,6 @@ class KodeverkService(
 class CachedKodeverkService(
     private val kodeverkClient: KodeverkClient,
 ) {
-    @Cacheable(sync = true)
+    @Cacheable("poststed", sync = true)
     fun hentPoststed(): KodeverkDto = kodeverkClient.hentPostnummer()
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/CachedKodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kodeverk/CachedKodeverkServiceTest.kt
@@ -1,0 +1,43 @@
+package no.nav.tilleggsstonader.soknad.kodeverk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.cache.annotation.Cacheable
+import java.lang.reflect.Modifier
+import kotlin.reflect.KClass
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.jvm.javaMethod
+
+internal class CachedKodeverkServiceTest {
+
+    // for å unngå at en metode som ikke @Cacheable kaller på en metode som er @Cacheable
+    @Test
+    internal fun `alle public metoder må være cacheable`() {
+        assertThat(sjekkAllePublicErCacheable(CachedKodeverkService::class)).isTrue()
+    }
+
+    @Test
+    internal fun `alle public metoder må være cacheable testklasse`() {
+        open class CachedKlasse {
+
+            @Cacheable
+            open fun med() = true
+
+            fun uten() = false
+        }
+
+        open class CachedKlasseMedPrivat {
+
+            @Cacheable
+            open fun med() = true
+
+            private fun uten() = false
+        }
+        assertThat(sjekkAllePublicErCacheable(CachedKlasse::class)).isFalse()
+        assertThat(sjekkAllePublicErCacheable(CachedKlasseMedPrivat::class)).isTrue()
+    }
+
+    private fun sjekkAllePublicErCacheable(kClass: KClass<*>) = kClass.declaredMemberFunctions
+        .filter { Modifier.isPublic(it.javaMethod!!.modifiers) }
+        .none { it.annotations.none { innerIt -> innerIt.annotationClass == Cacheable::class } }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20304

Den logger feil idag, trodde den skulle ta default funksjonsnavnet i tilfeller den ikke hadde med value.. 
La til en test for CacheableKodeverkService og

https://logs.adeo.no/s/nav-logs-legacy/app/discover#/doc/7304a984-dbca-4e06-bd4b-70e5c7c97f59/logstash-apps-prod-007018?id=KZsLdo4BZi3RtCTj8VsA


