### PR TITLE
Aktiviteter-api skal kun svare med stønadsberrettigede aktiviteter

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetController.kt
@@ -23,11 +23,16 @@ class AktivitetController(
     fun hentAktiviteter(): AktiviteterDto {
         val ident = EksternBrukerUtils.hentFnrFraToken()
         return try {
-            AktiviteterDto(aktivitetService.hentAktiviteter(ident).map { it.tilDto() }, suksess = true)
+            val aktiviteter = aktivitetService.hentAktiviteter(ident)
+            AktiviteterDto(
+                aktiviteter = aktiviteter.mapNotNull { it.tilDto() },
+                harAktiviteter = aktiviteter.isNotEmpty(),
+                suksess = true,
+            )
         } catch (e: Exception) {
             logger.error("Feilet henting av aktiviteter")
             secureLogger.error("Feiltet henting av aktiviteter for ident=$ident", e)
-            AktiviteterDto(emptyList(), suksess = false)
+            AktiviteterDto(emptyList(), harAktiviteter = false, suksess = false)
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetService.kt
@@ -12,8 +12,8 @@ class AktivitetService(
 
     @Cacheable("aktivitet", cacheManager = "aktivitetCache")
     fun hentAktiviteter(ident: String): List<AktivitetArenaDto> {
-        val fom = LocalDate.now().minusYears(1)
-        val tom = LocalDate.now().plusYears(1)
+        val fom = LocalDate.now().minusMonths(3)
+        val tom = LocalDate.now().plusMonths(3)
         return aktivitetClient.hentAKtiviteter(ident, fom, tom)
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
@@ -18,7 +18,7 @@ data class AktivitetDto(
     val fom: LocalDate,
     val tom: LocalDate?,
     val typeNavn: String,
-    val erUtdanning: Boolean?,
+    val erUtdanning: Boolean,
     val arrangør: String?,
 )
 
@@ -31,7 +31,7 @@ fun AktivitetArenaDto.tilDto(): AktivitetDto? {
         fom = fom,
         tom = tom,
         typeNavn = typeNavn,
-        erUtdanning = erUtdanning,
+        erUtdanning = erUtdanning == true,
         arrangør = arrangør,
     )
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
@@ -1,39 +1,37 @@
 package no.nav.tilleggsstonader.soknad.aktivitet
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
-import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
-import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
 import java.time.LocalDate
 
+/**
+ * @param aktiviteter er stønadsberrittgede aktiviteter
+ * @param harAktiviteter sier om det finnes aktiviteter generellt, då [aktiviteter] er filtrerte aktiviteter
+ */
 data class AktiviteterDto(
     val aktiviteter: List<AktivitetDto>,
+    val harAktiviteter: Boolean,
     val suksess: Boolean,
 )
 
 data class AktivitetDto(
     val id: String,
-    val fom: LocalDate?,
+    val fom: LocalDate,
     val tom: LocalDate?,
-    val type: String,
     val typeNavn: String,
-    val status: StatusAktivitet?,
-    val statusArena: String?,
-    val erStønadsberettiget: Boolean?,
     val erUtdanning: Boolean?,
     val arrangør: String?,
-    val kilde: Kilde,
 )
 
-fun AktivitetArenaDto.tilDto() = AktivitetDto(
-    id = id,
-    fom = fom,
-    tom = tom,
-    type = type,
-    typeNavn = typeNavn,
-    status = status,
-    statusArena = statusArena,
-    erStønadsberettiget = erStønadsberettiget,
-    erUtdanning = erUtdanning,
-    arrangør = arrangør,
-    kilde = kilde,
-)
+fun AktivitetArenaDto.tilDto(): AktivitetDto? {
+    val fom = this.fom ?: return null
+    if (this.erStønadsberettiget != true) return null
+
+    return AktivitetDto(
+        id = id,
+        fom = fom,
+        tom = tom,
+        typeNavn = typeNavn,
+        erUtdanning = erUtdanning,
+        arrangør = arrangør,
+    )
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDtoKtTest.kt
@@ -1,0 +1,72 @@
+package no.nav.tilleggsstonader.soknad.aktivitet
+
+import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
+import no.nav.tilleggsstonader.kontrakter.aktivitet.Kilde
+import no.nav.tilleggsstonader.kontrakter.aktivitet.StatusAktivitet
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class AktiviteterDtoKtTest {
+
+    @Nested
+    inner class TilDto {
+
+        @Test
+        fun `happy case mapping`() {
+            assertThat(dto().tilDto()).isEqualTo(
+                AktivitetDto(
+                    id = "1",
+                    fom = LocalDate.now(),
+                    tom = LocalDate.now().plusDays(1),
+                    typeNavn = "typeNavn",
+                    erUtdanning = true,
+                    arrangør = "arrangør",
+                ),
+            )
+        }
+
+        @Test
+        fun `returnerer null hvis fom mangler`() {
+            assertThat(dto(fom = null).tilDto()).isNull()
+        }
+
+        @Test
+        fun `returnerer null hvis erStønadsberettiget=false`() {
+            assertThat(dto(erStønadsberettiget = false).tilDto()).isNull()
+            assertThat(dto(erStønadsberettiget = null).tilDto()).isNull()
+        }
+    }
+
+    fun dto(
+        id: String = "1",
+        fom: LocalDate? = LocalDate.now(),
+        tom: LocalDate? = LocalDate.now().plusDays(1),
+        type: String = "type",
+        typeNavn: String = "typeNavn",
+        status: StatusAktivitet? = null,
+        statusArena: String? = null,
+        antallDagerPerUke: Int? = null,
+        prosentDeltakelse: BigDecimal? = null,
+        erStønadsberettiget: Boolean? = true,
+        erUtdanning: Boolean? = true,
+        arrangør: String? = "arrangør",
+        kilde: Kilde = Kilde.ARENA,
+    ) = AktivitetArenaDto(
+        id = id,
+        fom = fom,
+        tom = tom,
+        type = type,
+        typeNavn = typeNavn,
+        status = status,
+        statusArena = statusArena,
+        antallDagerPerUke = antallDagerPerUke,
+        prosentDeltakelse = prosentDeltakelse,
+        erStønadsberettiget = erStønadsberettiget,
+        erUtdanning = erUtdanning,
+        arrangør = arrangør,
+        kilde = kilde,
+    )
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ikke ønskelig å vise aktiviteter i frontend som ikke gir rett på stønaden. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-18543

Før:
<img width="473" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad-api/assets/937168/43776869-da7c-45bc-9790-c67bb184491f">

Etter:
<img width="471" alt="image" src="https://github.com/navikt/tilleggsstonader-soknad-api/assets/937168/16d81345-2850-4502-9934-de7e0f8bb27b">
