### PR TITLE
Skal hente aktiviteter ulik tid tilbake basert på stønadstype

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetController.kt
@@ -1,11 +1,15 @@
 package no.nav.tilleggsstonader.soknad.aktivitet
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.libs.log.SecureLogger.secureLogger
 import no.nav.tilleggsstonader.libs.sikkerhet.EksternBrukerUtils
 import org.slf4j.LoggerFactory
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -19,11 +23,29 @@ class AktivitetController(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @Deprecated("Erstattes av endepunkt som sender med stønadstype for å kunne variere hvor langt tilbake man henter aktiviteter")
     @GetMapping
-    fun hentAktiviteter(): AktiviteterDto {
+    fun hentAktiviteter(@PathVariable stønadstype: Stønadstype): AktiviteterDto {
         val ident = EksternBrukerUtils.hentFnrFraToken()
         return try {
-            val aktiviteter = aktivitetService.hentAktiviteter(ident)
+            val aktiviteter = aktivitetService.hentAktiviteter(ident, Stønadstype.BARNETILSYN)
+            AktiviteterDto(
+                aktiviteter = aktiviteter.gjeldende().mapNotNull { it.tilDto() }.sortedByDescending { it.fom },
+                harAktiviteter = aktiviteter.isNotEmpty(),
+                suksess = true,
+            )
+        } catch (e: Exception) {
+            logger.warn("Feilet henting av aktiviteter")
+            secureLogger.warn("Feiltet henting av aktiviteter for ident=$ident", e)
+            AktiviteterDto(emptyList(), harAktiviteter = false, suksess = false)
+        }
+    }
+
+    @PostMapping("v2")
+    fun hentAktiviteterV2(@RequestBody request: AktivitetRequest): AktiviteterDto {
+        val ident = EksternBrukerUtils.hentFnrFraToken()
+        return try {
+            val aktiviteter = aktivitetService.hentAktiviteter(ident, request.stønadstype)
             AktiviteterDto(
                 aktiviteter = aktiviteter.gjeldende().mapNotNull { it.tilDto() }.sortedByDescending { it.fom },
                 harAktiviteter = aktiviteter.isNotEmpty(),

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktiviteterDto.kt
@@ -2,6 +2,7 @@ package no.nav.tilleggsstonader.soknad.aktivitet
 
 import no.nav.tilleggsstonader.kontrakter.aktivitet.AktivitetArenaDto
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import java.time.LocalDate
 import kotlin.Boolean
 
@@ -56,3 +57,7 @@ fun AktivitetArenaDto.erUtdanningPåVgsNivå(): Boolean {
 fun List<AktivitetArenaDto>.gjeldende() = this
     .filter { it.erStønadsberettiget == true }
     .filter { it.status == null || it.status?.rettTilÅSøke == true }
+
+data class AktivitetRequest(
+    val stønadstype: Stønadstype,
+)

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/aktivitet/AktivitetServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.soknad.aktivitet
 import io.mockk.every
 import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.aktivitet.TypeAktivitet
+import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.IntegrationTest
 import no.nav.tilleggsstonader.soknad.infrastruktur.AktivitetClientConfig.Companion.resetMock
 import no.nav.tilleggsstonader.soknad.util.AktivitetArenaDtoUtil.aktivitetArenaDto
@@ -30,10 +31,10 @@ class AktivitetServiceTest : IntegrationTest() {
         every { aktivitetClient.hentAktiviteter("1", any(), any()) } returns listOf(aktivitetArenaDto("10"))
         every { aktivitetClient.hentAktiviteter("2", any(), any()) } returns listOf(aktivitetArenaDto("20"))
 
-        aktivitetService.hentAktiviteter("1")
-        val aktivitetIdent1 = aktivitetService.hentAktiviteter("1")
-        aktivitetService.hentAktiviteter("2")
-        val aktivitetIdent2 = aktivitetService.hentAktiviteter("2")
+        aktivitetService.hentAktiviteter("1", Stønadstype.BARNETILSYN)
+        val aktivitetIdent1 = aktivitetService.hentAktiviteter("1", Stønadstype.BARNETILSYN)
+        aktivitetService.hentAktiviteter("2", Stønadstype.BARNETILSYN)
+        val aktivitetIdent2 = aktivitetService.hentAktiviteter("2", Stønadstype.BARNETILSYN)
 
         assertThat(aktivitetIdent1.single().id).isEqualTo("10")
         assertThat(aktivitetIdent2.single().id).isEqualTo("20")
@@ -53,7 +54,7 @@ class AktivitetServiceTest : IntegrationTest() {
             ),
         )
 
-        val aktiviteter = aktivitetService.hentAktiviteter("1")
+        val aktiviteter = aktivitetService.hentAktiviteter("1", Stønadstype.BARNETILSYN)
         assertThat(aktiviteter).isEmpty()
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/util/AktivitetArenaDtoUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/util/AktivitetArenaDtoUtil.kt
@@ -15,8 +15,8 @@ object AktivitetArenaDtoUtil {
         type: TypeAktivitet = TypeAktivitet.JOBBK,
     ) = AktivitetArenaDto(
         id = id,
-        fom = osloDateNow(),
-        tom = osloDateNow(),
+        fom = osloDateNow().minusMonths(7),
+        tom = osloDateNow().minusMonths(5),
         type = type.name,
         typeNavn = "Type navn",
         status = StatusAktivitet.AKTUELL,

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/util/AktivitetArenaDtoUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/util/AktivitetArenaDtoUtil.kt
@@ -15,8 +15,8 @@ object AktivitetArenaDtoUtil {
         type: TypeAktivitet = TypeAktivitet.JOBBK,
     ) = AktivitetArenaDto(
         id = id,
-        fom = osloDateNow().minusMonths(7),
-        tom = osloDateNow().minusMonths(5),
+        fom = osloDateNow(),
+        tom = osloDateNow(),
         type = type.name,
         typeNavn = "Type navn",
         status = StatusAktivitet.AKTUELL,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Læremidler skal vise aktiviteter 6 mnd tilbake, barnetilsyn skal vise 3mnd. 

Er laget et nytt endepunkt for å unngå nedetid. Siden begge stønadene bruker samme endepunkt og vi ikke vet hvilken stønad det er snakk om når kallet gjøres så sendes stønadstype med til backend. 

⚠️ Må laste opp i dev for å sjekke at det faktisk fungerer. Til nå har jeg kun fått verifisert at riktige datoer plukkes ut basert på input, men lokalkjøring alltid returnerer aktiviteten fra mock uavhengig av dato.