### PR TITLE
Rename søknad til skjema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 val javaVersion = JavaLanguageVersion.of(21)
 val tilleggsstønaderLibsVersion = "2025.09.11-09.26.d3123ecc47ce"
-val tilleggsstønaderKontrakterVersion = "2025.10.02-10.04.6643a984d645"
+val tilleggsstønaderKontrakterVersion = "2025.10.07-10.37.272d2f70eee8"
 val familieProsesseringVersion = "2.20250908124930_1c1ba6c"
 val tokenSupportVersion = "5.0.37"
 val wiremockVersion = "3.0.1"

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapper.kt
@@ -9,32 +9,32 @@ import no.nav.tilleggsstonader.kontrakter.dokarkiv.dokumenttyper
 import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.felles.gjelderDagligReise
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 
 object ArkiverDokumentRequestMapper {
     fun toDto(
-        søknad: Søknad,
+        skjema: Skjema,
         vedlegg: List<Vedlegg>,
     ): ArkiverDokumentRequest {
-        val dokumenttype = typeHoveddokument(søknad.type)
+        val dokumenttype = typeHoveddokument(skjema.type)
         val søknadsdokumentJson =
             Dokument(
-                søknad.søknadJson.json.toByteArray(),
+                skjema.søknadJson.json.toByteArray(),
                 Filtype.JSON,
                 null,
                 dokumenttype.dokumentTittel(),
                 dokumenttype,
             )
         val søknadsdokumentPdf =
-            Dokument(søknad.søknadPdf!!, Filtype.PDFA, null, dokumenttype.dokumentTittel(), dokumenttype)
+            Dokument(skjema.søknadPdf!!, Filtype.PDFA, null, dokumenttype.dokumentTittel(), dokumenttype)
         return ArkiverDokumentRequest(
-            fnr = søknad.personIdent,
+            fnr = skjema.personIdent,
             forsøkFerdigstill = false,
             hoveddokumentvarianter = listOf(søknadsdokumentPdf, søknadsdokumentJson),
-            vedleggsdokumenter = mapVedlegg(vedlegg, søknad.type),
-            eksternReferanseId = søknad.id.toString(),
-            avsenderMottaker = AvsenderMottaker(id = søknad.personIdent, idType = BrukerIdType.FNR, navn = null),
+            vedleggsdokumenter = mapVedlegg(vedlegg, skjema.type),
+            eksternReferanseId = skjema.id.toString(),
+            avsenderMottaker = AvsenderMottaker(id = skjema.personIdent, idType = BrukerIdType.FNR, navn = null),
         )
     }
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapper.kt
@@ -20,14 +20,14 @@ object ArkiverDokumentRequestMapper {
         val dokumenttype = typeHoveddokument(skjema.type)
         val søknadsdokumentJson =
             Dokument(
-                skjema.søknadJson.json.toByteArray(),
+                skjema.skjemaJson.json.toByteArray(),
                 Filtype.JSON,
                 null,
                 dokumenttype.dokumentTittel(),
                 dokumenttype,
             )
         val søknadsdokumentPdf =
-            Dokument(skjema.søknadPdf!!, Filtype.PDFA, null, dokumenttype.dokumentTittel(), dokumenttype)
+            Dokument(skjema.skjemaPdf!!, Filtype.PDFA, null, dokumenttype.dokumentTittel(), dokumenttype)
         return ArkiverDokumentRequest(
             fnr = skjema.personIdent,
             forsøkFerdigstill = false,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
@@ -19,7 +19,7 @@ class ArkiveringService(
         callId: String,
     ) {
         val søknad = skjemaService.hentSkjema(søknadId)
-        val vedlegg = vedleggRepository.findBySøknadId(søknadId)
+        val vedlegg = vedleggRepository.findBySkjemaId(søknadId)
         val journalpostId: String = send(søknad, vedlegg)
 
         skjemaService.oppdaterSkjema(søknad.copy(journalpostId = journalpostId))

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
@@ -14,15 +14,15 @@ class ArkiveringService(
     private val skjemaService: SkjemaService,
     private val vedleggRepository: VedleggRepository,
 ) {
-    fun journalførSøknad(
-        søknadId: UUID,
+    fun journalførSkjema(
+        skjemaId: UUID,
         callId: String,
     ) {
-        val søknad = skjemaService.hentSkjema(søknadId)
-        val vedlegg = vedleggRepository.findBySkjemaId(søknadId)
-        val journalpostId: String = send(søknad, vedlegg)
+        val skjema = skjemaService.hentSkjema(skjemaId)
+        val vedlegg = vedleggRepository.findBySkjemaId(skjemaId)
+        val journalpostId: String = send(skjema, vedlegg)
 
-        skjemaService.oppdaterSkjema(søknad.copy(journalpostId = journalpostId))
+        skjemaService.oppdaterSkjema(skjema.copy(journalpostId = journalpostId))
     }
 
     private fun send(

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.soknad.arkivering
 
 import no.nav.tilleggsstonader.soknad.infrastruktur.IntegrasjonerClient
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
@@ -11,18 +11,18 @@ import java.util.UUID
 @Service
 class ArkiveringService(
     private val integrasjonerClient: IntegrasjonerClient,
-    private val søknadService: SøknadService,
+    private val skjemaService: SkjemaService,
     private val vedleggRepository: VedleggRepository,
 ) {
     fun journalførSøknad(
         søknadId: UUID,
         callId: String,
     ) {
-        val søknad = søknadService.hentSøknad(søknadId)
+        val søknad = skjemaService.hentSkjema(søknadId)
         val vedlegg = vedleggRepository.findBySøknadId(søknadId)
         val journalpostId: String = send(søknad, vedlegg)
 
-        søknadService.oppdaterSøknad(søknad.copy(journalpostId = journalpostId))
+        skjemaService.oppdaterSkjema(søknad.copy(journalpostId = journalpostId))
     }
 
     private fun send(

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringService.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.soknad.arkivering
 
 import no.nav.tilleggsstonader.soknad.infrastruktur.IntegrasjonerClient
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
 import org.springframework.stereotype.Service
@@ -26,10 +26,10 @@ class ArkiveringService(
     }
 
     private fun send(
-        søknad: Søknad,
+        skjema: Skjema,
         vedlegg: List<Vedlegg>,
     ): String {
-        val arkiverDokumentRequest = ArkiverDokumentRequestMapper.toDto(søknad, vedlegg)
+        val arkiverDokumentRequest = ArkiverDokumentRequestMapper.toDto(skjema, vedlegg)
         val dokumentResponse = integrasjonerClient.arkiver(arkiverDokumentRequest)
         return dokumentResponse.journalpostId
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfService.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.sak.DokumentBrevkode
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaLæremidler
 import no.nav.tilleggsstonader.soknad.dokument.pdf.SpråkMapper.tittelSøknadsskjema
@@ -13,20 +13,20 @@ import no.nav.tilleggsstonader.soknad.dokument.pdf.Søkerinformasjon
 import no.nav.tilleggsstonader.soknad.dokument.pdf.SøknadTreeWalker.mapSøknad
 import no.nav.tilleggsstonader.soknad.dokument.pdf.VedleggMapper.mapVedlegg
 import no.nav.tilleggsstonader.soknad.person.PersonService
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
 class PdfService(
-    private val søknadService: SøknadService,
+    private val skjemaService: SkjemaService,
     private val personService: PersonService,
     private val htmlifyClient: HtmlifyClient,
     private val dokumentClient: FamilieDokumentClient,
 ) {
     fun lagPdf(søknadId: UUID) {
-        val søknad = søknadService.hentSøknad(søknadId)
+        val søknad = skjemaService.hentSkjema(søknadId)
         val søknadsskjema = parseSøknadsskjema(søknad)
         val felter = mapSøknad(søknadsskjema, hentSøkerinformasjon(søknad))
         val html =
@@ -39,16 +39,16 @@ class PdfService(
                 dokumentBrevkode = dokumentBrevKode(søknadsskjema),
             )
         val pdf = dokumentClient.genererPdf(html)
-        søknadService.oppdaterSøknad(søknad.copy(søknadPdf = pdf))
+        skjemaService.oppdaterSkjema(søknad.copy(skjemaPdf = pdf))
     }
 
     // TODO - mappe dokumentbrevkode fra skjematype
-    private fun dokumentBrevKode(søknadsskjema: Søknadsskjema<*>): DokumentBrevkode =
-        when (søknadsskjema.skjema) {
+    private fun dokumentBrevKode(innsendtSkjema: InnsendtSkjema<*>): DokumentBrevkode =
+        when (innsendtSkjema.skjema) {
             is SøknadsskjemaBarnetilsyn -> DokumentBrevkode.BARNETILSYN
             is SøknadsskjemaLæremidler -> DokumentBrevkode.LÆREMIDLER
             is KjørelisteSkjema -> DokumentBrevkode.DAGLIG_REISE_KJØRELISTE
-            else -> error("Ingen dokumentbrevkode for skjema ${søknadsskjema.skjema::class.qualifiedName}")
+            else -> error("Ingen dokumentbrevkode for skjema ${innsendtSkjema.skjema::class.qualifiedName}")
         }
 
     private fun hentSøkerinformasjon(skjema: Skjema): Søkerinformasjon {
@@ -56,12 +56,12 @@ class PdfService(
         return Søkerinformasjon(ident = skjema.personIdent, navn = navn)
     }
 
-    private fun parseSøknadsskjema(skjema: Skjema): Søknadsskjema<*> {
-        val json = skjema.søknadJson.json
+    private fun parseSøknadsskjema(skjema: Skjema): InnsendtSkjema<*> {
+        val json = skjema.skjemaJson.json
         return when (skjema.type) {
-            Stønadstype.BARNETILSYN -> objectMapper.readValue<Søknadsskjema<SøknadsskjemaBarnetilsyn>>(json)
-            Stønadstype.LÆREMIDLER -> objectMapper.readValue<Søknadsskjema<SøknadsskjemaLæremidler>>(json)
-            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR -> objectMapper.readValue<Søknadsskjema<KjørelisteSkjema>>(json)
+            Stønadstype.BARNETILSYN -> objectMapper.readValue<InnsendtSkjema<SøknadsskjemaBarnetilsyn>>(json)
+            Stønadstype.LÆREMIDLER -> objectMapper.readValue<InnsendtSkjema<SøknadsskjemaLæremidler>>(json)
+            Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR -> objectMapper.readValue<InnsendtSkjema<KjørelisteSkjema>>(json)
             Stønadstype.BOUTGIFTER ->
                 error("Har ikke laget søknad for ${skjema.type}")
         }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfService.kt
@@ -14,7 +14,7 @@ import no.nav.tilleggsstonader.soknad.dokument.pdf.SøknadTreeWalker.mapSøknad
 import no.nav.tilleggsstonader.soknad.dokument.pdf.VedleggMapper.mapVedlegg
 import no.nav.tilleggsstonader.soknad.person.PersonService
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -51,19 +51,19 @@ class PdfService(
             else -> error("Ingen dokumentbrevkode for skjema ${søknadsskjema.skjema::class.qualifiedName}")
         }
 
-    private fun hentSøkerinformasjon(søknad: Søknad): Søkerinformasjon {
-        val navn = personService.hentNavnMedClientCredential(søknad.personIdent)
-        return Søkerinformasjon(ident = søknad.personIdent, navn = navn)
+    private fun hentSøkerinformasjon(skjema: Skjema): Søkerinformasjon {
+        val navn = personService.hentNavnMedClientCredential(skjema.personIdent)
+        return Søkerinformasjon(ident = skjema.personIdent, navn = navn)
     }
 
-    private fun parseSøknadsskjema(søknad: Søknad): Søknadsskjema<*> {
-        val json = søknad.søknadJson.json
-        return when (søknad.type) {
+    private fun parseSøknadsskjema(skjema: Skjema): Søknadsskjema<*> {
+        val json = skjema.søknadJson.json
+        return when (skjema.type) {
             Stønadstype.BARNETILSYN -> objectMapper.readValue<Søknadsskjema<SøknadsskjemaBarnetilsyn>>(json)
             Stønadstype.LÆREMIDLER -> objectMapper.readValue<Søknadsskjema<SøknadsskjemaLæremidler>>(json)
             Stønadstype.DAGLIG_REISE_TSO, Stønadstype.DAGLIG_REISE_TSR -> objectMapper.readValue<Søknadsskjema<KjørelisteSkjema>>(json)
             Stønadstype.BOUTGIFTER ->
-                error("Har ikke laget søknad for ${søknad.type}")
+                error("Har ikke laget søknad for ${skjema.type}")
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/SpråkMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/SpråkMapper.kt
@@ -1,8 +1,8 @@
 package no.nav.tilleggsstonader.soknad.dokument.pdf
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaLæremidler
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.AktivitetAvsnitt
@@ -14,7 +14,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.læremidler.UtdanningAvsnitt
 import kotlin.reflect.KClass
 
 object SpråkMapper {
-    fun tittelSøknadsskjema(søknad: Søknadsskjema<*>): String {
+    fun tittelSøknadsskjema(søknad: InnsendtSkjema<*>): String {
         val kClass = søknad.skjema::class
         val språk = søknad.språk
         return tittelSøknadsskjemaMapper[kClass]?.get(språk)

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/SøknadTreeWalker.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/SøknadTreeWalker.kt
@@ -5,11 +5,11 @@ import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.DokumentasjonFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFlereValgFelt
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.NumeriskFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.Reisedag
 import no.nav.tilleggsstonader.kontrakter.søknad.SelectFelt
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaLæremidler
 import no.nav.tilleggsstonader.kontrakter.søknad.TekstFelt
@@ -65,7 +65,7 @@ data object HorisontalLinje : HtmlFelt(HtmlFeltType.LINJE)
 
 object SøknadTreeWalker {
     fun mapSøknad(
-        søknad: Søknadsskjema<*>,
+        søknad: InnsendtSkjema<*>,
         søkerinformasjon: Søkerinformasjon,
     ): List<HtmlFelt> = listOf(søkerinformasjon.tilAvsnitt(søknad.språk)) + mapFelter(søknad.skjema, søknad.språk)
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/VedleggMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/dokument/pdf/VedleggMapper.kt
@@ -2,13 +2,13 @@ package no.nav.tilleggsstonader.soknad.dokument.pdf
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 import no.nav.tilleggsstonader.kontrakter.søknad.DokumentasjonFelt
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.soknad.dokument.Dokument
 import no.nav.tilleggsstonader.soknad.dokument.DokumentasjonAvsnitt
 
 object VedleggMapper {
-    fun mapVedlegg(søknad: Søknadsskjema<*>): List<DokumentasjonAvsnitt> {
+    fun mapVedlegg(søknad: InnsendtSkjema<*>): List<DokumentasjonAvsnitt> {
         require(søknad.språk == Språkkode.NB) {
             "Må legge inn mapping av språk ${søknad.språk} for vedlegg: tittel, har sendt inn tidligere "
         }
@@ -37,7 +37,7 @@ object VedleggMapper {
             )
         }
 
-    private fun mapBarnIdentTilNavn(søknad: Søknadsskjema<*>): Map<String, String> {
+    private fun mapBarnIdentTilNavn(søknad: InnsendtSkjema<*>): Map<String, String> {
         val skjema = søknad.skjema
         return if (skjema is SøknadsskjemaBarnetilsyn) {
             skjema.barn.barnMedBarnepass.associate { it.ident.verdi to it.navn.verdi }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteController.kt
@@ -2,7 +2,7 @@ package no.nav.tilleggsstonader.soknad.kjøreliste
 
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.tilleggsstonader.libs.sikkerhet.EksternBrukerUtils
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,7 +18,7 @@ import kotlin.random.Random
 @ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 @Validated
 class KjørelisteController(
-    private val søknadService: SøknadService,
+    private val skjemaService: SkjemaService,
 ) {
     @GetMapping("alle-rammevedtak")
     fun hentAlleRammevedtak(): List<RammevedtakDto> = rammevedtakDtoMock
@@ -32,7 +32,7 @@ class KjørelisteController(
     fun mottaKjørelister(
         @RequestBody kjørelisteDto: KjørelisteDto,
     ): KjørelisteResponse {
-        søknadService.lagreKjøreliste(
+        skjemaService.lagreKjøreliste(
             ident = EksternBrukerUtils.hentFnrFraToken(),
             mottattTidspunkt = LocalDateTime.now(),
             kjøreliste = kjørelisteDto,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteMapper.kt
@@ -1,9 +1,9 @@
 package no.nav.tilleggsstonader.soknad.kjøreliste
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.Reisedag
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.UkeMedReisedager
 import java.time.LocalDateTime
 
@@ -12,9 +12,9 @@ object KjørelisteMapper {
         ident: String,
         mottattTidspunkt: LocalDateTime,
         dto: KjørelisteDto,
-    ): Søknadsskjema<KjørelisteSkjema> {
+    ): InnsendtSkjema<KjørelisteSkjema> {
         val språkkode = Språkkode.NB
-        return Søknadsskjema(
+        return InnsendtSkjema(
             ident = ident,
             mottattTidspunkt = mottattTidspunkt,
             språk = språkkode,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/metrics/SøknadMetricService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/metrics/SøknadMetricService.kt
@@ -4,20 +4,20 @@ import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
-import no.nav.tilleggsstonader.soknad.soknad.domene.SøknadRepository
+import no.nav.tilleggsstonader.soknad.soknad.domene.SkjemaRepository
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 @Service
 class SøknadMetricService(
-    private val søknadRepository: SøknadRepository,
+    private val skjemaRepository: SkjemaRepository,
 ) {
     private val antallRoutingsGauge = MultiGauge.builder("soknader_antall").register(Metrics.globalRegistry)
 
     @Scheduled(initialDelay = MetricUtil.FREKVENS_30_SEC, fixedDelay = MetricUtil.FREKVENS_30_MIN)
     fun antallRoutings() {
         val rows =
-            søknadRepository.finnAntallPerType().map {
+            skjemaRepository.finnAntallPerType().map {
                 MultiGauge.Row.of(Tags.of(Tag.of("ytelse", it.type.name)), it.count)
             }
         antallRoutingsGauge.register(rows, true)

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/ArkiverSøknadTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/ArkiverSøknadTask.kt
@@ -15,8 +15,8 @@ class ArkiverSøknadTask(
     private val taskService: TaskService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val søknadId = UUID.fromString(task.payload)
-        arkiveringService.journalførSøknad(søknadId, task.callId)
+        val skjemaId = UUID.fromString(task.payload)
+        arkiveringService.journalførSkjema(skjemaId, task.callId)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/LagPdfTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/LagPdfTask.kt
@@ -17,8 +17,8 @@ class LagPdfTask(
     private val taskService: TaskService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val søknadId = UUID.fromString(task.payload)
-        pdfService.lagPdf(søknadId)
+        val skjemaId = UUID.fromString(task.payload)
+        pdfService.lagPdf(skjemaId)
     }
 
     override fun onCompletion(task: Task) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/LagPdfTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/LagPdfTask.kt
@@ -5,7 +5,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.soknad.dokument.PdfService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import org.springframework.stereotype.Service
 import java.util.Properties
 import java.util.UUID
@@ -28,13 +28,13 @@ class LagPdfTask(
     companion object {
         const val TYPE = "LAG_PDF"
 
-        fun opprettTask(søknad: Søknad): Task {
+        fun opprettTask(skjema: Skjema): Task {
             val properties =
                 Properties().apply {
-                    setProperty("søkersFødselsnummer", søknad.personIdent)
-                    setProperty("type", søknad.type.name)
+                    setProperty("søkersFødselsnummer", skjema.personIdent)
+                    setProperty("type", skjema.type.name)
                 }
-            return Task(TYPE, søknad.id.toString(), properties)
+            return Task(TYPE, skjema.id.toString(), properties)
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTask.kt
@@ -5,7 +5,7 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.varsel.DittNavKafkaProducer
 import org.springframework.stereotype.Service
 import java.util.Properties
@@ -36,13 +36,13 @@ class SendNotifikasjonTask(
     companion object {
         const val TYPE = "SEND_NOTIFIKASJON"
 
-        fun opprettTask(søknad: Søknad): Task {
+        fun opprettTask(skjema: Skjema): Task {
             val properties =
                 Properties().apply {
-                    setProperty("søkersFødselsnummer", søknad.personIdent)
-                    setProperty("type", søknad.type.name)
+                    setProperty("søkersFødselsnummer", skjema.personIdent)
+                    setProperty("type", skjema.type.name)
                 }
-            return Task(TYPE, søknad.id.toString(), properties)
+            return Task(TYPE, skjema.id.toString(), properties)
         }
     }
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTask.kt
@@ -4,7 +4,7 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.varsel.DittNavKafkaProducer
 import org.springframework.stereotype.Service
@@ -15,10 +15,10 @@ import java.util.UUID
 @TaskStepBeskrivelse(taskStepType = SendNotifikasjonTask.TYPE, beskrivelse = "Send notifikasjon mottatt søknad")
 class SendNotifikasjonTask(
     private val notifikasjonsService: DittNavKafkaProducer,
-    private val søknadService: SøknadService,
+    private val skjemaService: SkjemaService,
 ) : AsyncTaskStep {
     override fun doTask(task: Task) {
-        val søknad = søknadService.hentSøknad(UUID.fromString(task.payload))
+        val søknad = skjemaService.hentSkjema(UUID.fromString(task.payload))
         val message = lagNotifikasjonsMelding(søknad.type)
         val eventId = søknad.id.toString()
 

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SkjemaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SkjemaService.kt
@@ -172,7 +172,7 @@ class SkjemaService(
             vedlegg.map {
                 Vedlegg(
                     id = it.id,
-                    søknadId = skjemaDb.id,
+                    skjemaId = skjemaDb.id,
                     type = it.type,
                     navn = it.navn,
                     innhold = it.data,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadController.kt
@@ -16,14 +16,14 @@ import java.time.LocalDateTime
 @ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
 @Validated
 class SøknadController(
-    private val søknadService: SøknadService,
+    private val skjemaService: SkjemaService,
 ) {
     @PostMapping("pass-av-barn")
     fun sendInn(
         @RequestBody søknad: SøknadBarnetilsynDto,
     ): Kvittering {
         val mottattTidspunkt = LocalDateTime.now()
-        søknadService.lagreSøknad(
+        skjemaService.lagreSøknadTilsynBarn(
             ident = EksternBrukerUtils.hentFnrFraToken(),
             mottattTidspunkt = mottattTidspunkt,
             søknad = søknad,
@@ -36,7 +36,7 @@ class SøknadController(
         @RequestBody søknad: SøknadLæremidlerDto,
     ): Kvittering {
         val mottattTidspunkt = LocalDateTime.now()
-        søknadService.lagreLæremidlerSøknad(
+        skjemaService.lagreLæremidlerSøknad(
             ident = EksternBrukerUtils.hentFnrFraToken(),
             mottattTidspunkt = mottattTidspunkt,
             søknad = søknad,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.søknad.DokumentasjonFelt
-import no.nav.tilleggsstonader.kontrakter.søknad.Skjema
+import no.nav.tilleggsstonader.kontrakter.søknad.Skjemadata
 import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.Vedleggstype
 import no.nav.tilleggsstonader.libs.utils.fnr.Fødselsnummer
@@ -19,7 +19,7 @@ import no.nav.tilleggsstonader.soknad.prosessering.LagPdfTask
 import no.nav.tilleggsstonader.soknad.prosessering.SendNotifikasjonTask
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.BarnetilsynMapper
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynDto
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.SøknadRepository
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
@@ -40,10 +40,10 @@ class SøknadService(
     private val personService: PersonService,
     private val familieVedleggClient: FamilieVedleggClient,
 ) {
-    fun hentSøknad(id: UUID): Søknad = søknadRepository.findByIdOrThrow(id)
+    fun hentSøknad(id: UUID): Skjema = søknadRepository.findByIdOrThrow(id)
 
-    fun oppdaterSøknad(søknad: Søknad) {
-        søknadRepository.update(søknad)
+    fun oppdaterSøknad(skjema: Skjema) {
+        søknadRepository.update(skjema)
     }
 
     @Transactional
@@ -145,34 +145,34 @@ class SøknadService(
         }
     }
 
-    private fun <T : Skjema> lagreSøknad(
+    private fun <T : Skjemadata> lagreSøknad(
         type: Stønadstype,
         søknadsskjema: Søknadsskjema<T>,
         vedlegg: List<Vedleggholder>,
         søknadFrontendGitHash: String?,
-    ): Søknad {
-        val søknadDb =
+    ): Skjema {
+        val skjemaDb =
             søknadRepository.insert(
-                Søknad(
+                Skjema(
                     type = type,
                     personIdent = søknadsskjema.ident,
                     søknadJson = JsonWrapper(objectMapper.writeValueAsString(søknadsskjema)),
                     søknadFrontendGitHash = søknadFrontendGitHash,
                 ),
             )
-        lagreVedlegg(søknadDb, vedlegg)
-        return søknadDb
+        lagreVedlegg(skjemaDb, vedlegg)
+        return skjemaDb
     }
 
     private fun lagreVedlegg(
-        søknadDb: Søknad,
+        skjemaDb: Skjema,
         vedlegg: List<Vedleggholder>,
     ) {
         vedleggRepository.insertAll(
             vedlegg.map {
                 Vedlegg(
                     id = it.id,
-                    søknadId = søknadDb.id,
+                    søknadId = skjemaDb.id,
                     type = it.type,
                     navn = it.navn,
                     innhold = it.data,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/barnetilsyn/BarnetilsynMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/barnetilsyn/BarnetilsynMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.soknad.soknad.barnetilsyn
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaBarnetilsyn
 import no.nav.tilleggsstonader.kontrakter.søknad.TekstFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.barnetilsyn.AktivitetAvsnitt
@@ -20,9 +20,9 @@ class BarnetilsynMapper {
         mottattTidspunkt: LocalDateTime,
         pdlBarn: Map<String, Barn>,
         dto: SøknadBarnetilsynDto,
-    ): Søknadsskjema<SøknadsskjemaBarnetilsyn> {
+    ): InnsendtSkjema<SøknadsskjemaBarnetilsyn> {
         val språkkode = Språkkode.NB
-        return Søknadsskjema(
+        return InnsendtSkjema(
             ident = ident,
             mottattTidspunkt = mottattTidspunkt,
             språk = språkkode,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SkjemaRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SkjemaRepository.kt
@@ -15,7 +15,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
-interface SøknadRepository :
+interface SkjemaRepository :
     RepositoryInterface<Skjema, UUID>,
     InsertUpdateRepository<Skjema> {
     @Query("SELECT type, count(*) as count FROM skjema GROUP BY type")
@@ -35,14 +35,14 @@ data class Skjema(
     val type: Stønadstype,
     val personIdent: String,
     @Column("skjema_json")
-    val søknadJson: JsonWrapper,
+    val skjemaJson: JsonWrapper,
     @Column("skjema_pdf")
-    val søknadPdf: ByteArray? = null,
+    val skjemaPdf: ByteArray? = null,
     val journalpostId: String? = null,
     @Version
     val version: Int = 0,
     @Column("frontend_git_hash")
-    val søknadFrontendGitHash: String?,
+    val frontendGitHash: String?,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -54,11 +54,11 @@ data class Skjema(
         if (opprettetTid != other.opprettetTid) return false
         if (type != other.type) return false
         if (personIdent != other.personIdent) return false
-        if (søknadJson != other.søknadJson) return false
-        if (søknadPdf != null) {
-            if (other.søknadPdf == null) return false
-            if (!søknadPdf.contentEquals(other.søknadPdf)) return false
-        } else if (other.søknadPdf != null) {
+        if (skjemaJson != other.skjemaJson) return false
+        if (skjemaPdf != null) {
+            if (other.skjemaPdf == null) return false
+            if (!skjemaPdf.contentEquals(other.skjemaPdf)) return false
+        } else if (other.skjemaPdf != null) {
             return false
         }
         if (journalpostId != other.journalpostId) return false
@@ -70,8 +70,8 @@ data class Skjema(
         result = 31 * result + opprettetTid.hashCode()
         result = 31 * result + type.hashCode()
         result = 31 * result + personIdent.hashCode()
-        result = 31 * result + søknadJson.hashCode()
-        result = 31 * result + (søknadPdf?.contentHashCode() ?: 0)
+        result = 31 * result + skjemaJson.hashCode()
+        result = 31 * result + (skjemaPdf?.contentHashCode() ?: 0)
         result = 31 * result + (journalpostId?.hashCode() ?: 0)
         result = 31 * result + version
         return result

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepository.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 interface SøknadRepository :
     RepositoryInterface<Søknad, UUID>,
     InsertUpdateRepository<Søknad> {
-    @Query("SELECT type, count(*) as count FROM soknad GROUP BY type")
+    @Query("SELECT type, count(*) as count FROM skjema GROUP BY type")
     fun finnAntallPerType(): List<AntallPerType>
 }
 
@@ -27,21 +27,21 @@ data class AntallPerType(
     val count: Long,
 )
 
-@Table("soknad")
+@Table("skjema")
 data class Søknad(
     @Id
     val id: UUID = UUID.randomUUID(),
     val opprettetTid: LocalDateTime = SporbarUtils.now(),
     val type: Stønadstype,
     val personIdent: String,
-    @Column("soknad_json")
+    @Column("skjema_json")
     val søknadJson: JsonWrapper,
-    @Column("soknad_pdf")
+    @Column("skjema_pdf")
     val søknadPdf: ByteArray? = null,
     val journalpostId: String? = null,
     @Version
     val version: Int = 0,
-    @Column("soknad_frontend_git_hash")
+    @Column("frontend_git_hash")
     val søknadFrontendGitHash: String?,
 ) {
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepository.kt
@@ -16,8 +16,8 @@ import java.util.UUID
 
 @Repository
 interface SøknadRepository :
-    RepositoryInterface<Søknad, UUID>,
-    InsertUpdateRepository<Søknad> {
+    RepositoryInterface<Skjema, UUID>,
+    InsertUpdateRepository<Skjema> {
     @Query("SELECT type, count(*) as count FROM skjema GROUP BY type")
     fun finnAntallPerType(): List<AntallPerType>
 }
@@ -28,7 +28,7 @@ data class AntallPerType(
 )
 
 @Table("skjema")
-data class Søknad(
+data class Skjema(
     @Id
     val id: UUID = UUID.randomUUID(),
     val opprettetTid: LocalDateTime = SporbarUtils.now(),
@@ -48,7 +48,7 @@ data class Søknad(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as Søknad
+        other as Skjema
 
         if (id != other.id) return false
         if (opprettetTid != other.opprettetTid) return false

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepository.kt
@@ -14,14 +14,14 @@ import java.util.UUID
 interface VedleggRepository :
     RepositoryInterface<Vedlegg, UUID>,
     InsertUpdateRepository<Vedlegg> {
-    fun findBySøknadId(søknadId: UUID): List<Vedlegg>
+    fun findBySkjemaId(skjemaId: UUID): List<Vedlegg>
 }
 
 class Vedlegg(
     @Id
     val id: UUID,
-    @Column("soknad_id")
-    val søknadId: UUID,
+    @Column("skjema_id")
+    val skjemaId: UUID,
     val type: Vedleggstype,
     val navn: String,
     val innhold: ByteArray,
@@ -37,7 +37,7 @@ class Vedlegg(
         other as Vedlegg
 
         if (id != other.id) return false
-        if (søknadId != other.søknadId) return false
+        if (skjemaId != other.skjemaId) return false
         if (type != other.type) return false
         if (navn != other.navn) return false
         if (!innhold.contentEquals(other.innhold)) return false
@@ -46,7 +46,7 @@ class Vedlegg(
 
     override fun hashCode(): Int {
         var result = id.hashCode()
-        result = 31 * result + søknadId.hashCode()
+        result = 31 * result + skjemaId.hashCode()
         result = 31 * result + type.hashCode()
         result = 31 * result + navn.hashCode()
         result = 31 * result + innhold.contentHashCode()

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/læremidler/LæremidlerMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/læremidler/LæremidlerMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.tilleggsstonader.soknad.soknad.læremidler
 
 import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.SøknadsskjemaLæremidler
 import no.nav.tilleggsstonader.kontrakter.søknad.læremidler.HarRettTilUtstyrsstipend
 import no.nav.tilleggsstonader.kontrakter.søknad.læremidler.UtdanningAvsnitt
@@ -15,9 +15,9 @@ class LæremidlerMapper {
         ident: String,
         mottattTidspunkt: LocalDateTime,
         dto: SøknadLæremidlerDto,
-    ): Søknadsskjema<SøknadsskjemaLæremidler> {
+    ): InnsendtSkjema<SøknadsskjemaLæremidler> {
         val språkkode = Språkkode.NB
-        return Søknadsskjema(
+        return InnsendtSkjema(
             ident = ident,
             mottattTidspunkt = mottattTidspunkt,
             språk = språkkode,

--- a/src/main/resources/db/migration/V6__rename_søknad_tabell.sql
+++ b/src/main/resources/db/migration/V6__rename_søknad_tabell.sql
@@ -1,0 +1,4 @@
+ALTER TABLE soknad RENAME TO skjema;
+ALTER TABLE skjema RENAME COLUMN soknad_json TO skjema_json;
+ALTER TABLE skjema RENAME COLUMN soknad_pdf TO skjema_pdf;
+ALTER TABLE skjema RENAME COLUMN soknad_frontend_git_hash TO frontend_git_hash;

--- a/src/main/resources/db/migration/V6__rename_søknad_tabell.sql
+++ b/src/main/resources/db/migration/V6__rename_søknad_tabell.sql
@@ -2,3 +2,5 @@ ALTER TABLE soknad RENAME TO skjema;
 ALTER TABLE skjema RENAME COLUMN soknad_json TO skjema_json;
 ALTER TABLE skjema RENAME COLUMN soknad_pdf TO skjema_pdf;
 ALTER TABLE skjema RENAME COLUMN soknad_frontend_git_hash TO frontend_git_hash;
+
+ALTER TABLE vedlegg RENAME COLUMN soknad_id TO skjema_id;

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/IntegrationTest.kt
@@ -10,7 +10,7 @@ import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import no.nav.tilleggsstonader.libs.test.fnr.FnrGenerator
 import no.nav.tilleggsstonader.soknad.infrastruktur.PdlClientConfig.Companion.resetPdlClientMock
 import no.nav.tilleggsstonader.soknad.person.pdl.PdlClient
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 import no.nav.tilleggsstonader.soknad.util.DbContainerInitializer
 import org.junit.jupiter.api.AfterEach
@@ -99,7 +99,7 @@ abstract class IntegrationTest {
             TaskLogg::class,
             Task::class,
             Vedlegg::class,
-            Søknad::class,
+            Skjema::class,
         ).forEach { jdbcAggregateOperations.deleteAll(it.java) }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapperTest.kt
@@ -8,7 +8,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.Vedleggstype
 import no.nav.tilleggsstonader.soknad.arkivering.ArkiverDokumentRequestMapper.toDto
 import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynUtil
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -41,7 +41,7 @@ internal class ArkiverDokumentRequestMapperTest {
     private fun lagSøknad(
         søknad: Any,
         type: Stønadstype,
-    ) = Søknad(
+    ) = Skjema(
         søknadJson = JsonWrapper(objectMapper.writeValueAsString(søknad)),
         personIdent = "123",
         type = type,

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapperTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiverDokumentRequestMapperTest.kt
@@ -42,11 +42,11 @@ internal class ArkiverDokumentRequestMapperTest {
         søknad: Any,
         type: Stønadstype,
     ) = Skjema(
-        søknadJson = JsonWrapper(objectMapper.writeValueAsString(søknad)),
+        skjemaJson = JsonWrapper(objectMapper.writeValueAsString(søknad)),
         personIdent = "123",
         type = type,
-        søknadPdf = byteArrayOf(12),
-        søknadFrontendGitHash = "aabbccd",
+        skjemaPdf = byteArrayOf(12),
+        frontendGitHash = "aabbccd",
     )
 
     private fun lagVedlegg() =

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.infrastruktur.IntegrasjonerClient
 import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -28,8 +28,8 @@ internal class ArkiveringServiceTest {
             vedleggRepository,
         )
 
-    private val søknad =
-        Søknad(
+    private val skjema =
+        Skjema(
             søknadJson = JsonWrapper(""),
             type = Stønadstype.BARNETILSYN,
             personIdent = "1",
@@ -38,14 +38,14 @@ internal class ArkiveringServiceTest {
             søknadFrontendGitHash = "aabbccd",
         )
 
-    val oppdaterSøknadSlot = slot<Søknad>()
+    val oppdaterSkjemaSlot = slot<Skjema>()
 
     @BeforeEach
     fun setUp() {
-        oppdaterSøknadSlot.clear()
-        every { søknadService.hentSøknad(søknad.id) } returns søknad
-        every { vedleggRepository.findBySøknadId(søknad.id) } returns emptyList()
-        justRun { søknadService.oppdaterSøknad(capture(oppdaterSøknadSlot)) }
+        oppdaterSkjemaSlot.clear()
+        every { søknadService.hentSøknad(skjema.id) } returns skjema
+        every { vedleggRepository.findBySøknadId(skjema.id) } returns emptyList()
+        justRun { søknadService.oppdaterSøknad(capture(oppdaterSkjemaSlot)) }
     }
 
     @Test
@@ -53,7 +53,7 @@ internal class ArkiveringServiceTest {
         val journalpostId = "journalpostId_1"
         every { integrasjonerClient.arkiver(any()) } returns
             ArkiverDokumentResponse(journalpostId, false, emptyList())
-        arkiveringService.journalførSøknad(søknad.id, "callId")
-        assertThat(oppdaterSøknadSlot.captured.journalpostId).isEqualTo(journalpostId)
+        arkiveringService.journalførSøknad(skjema.id, "callId")
+        assertThat(oppdaterSkjemaSlot.captured.journalpostId).isEqualTo(journalpostId)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
@@ -53,7 +53,7 @@ internal class ArkiveringServiceTest {
         val journalpostId = "journalpostId_1"
         every { integrasjonerClient.arkiver(any()) } returns
             ArkiverDokumentResponse(journalpostId, false, emptyList())
-        arkiveringService.journalførSøknad(skjema.id, "callId")
+        arkiveringService.journalførSkjema(skjema.id, "callId")
         assertThat(oppdaterSkjemaSlot.captured.journalpostId).isEqualTo(journalpostId)
     }
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
@@ -8,7 +8,7 @@ import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.infrastruktur.IntegrasjonerClient
 import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -18,24 +18,24 @@ import java.time.LocalDateTime
 
 internal class ArkiveringServiceTest {
     private val integrasjonerClient = mockk<IntegrasjonerClient>()
-    private val søknadService = mockk<SøknadService>()
+    private val skjemaService = mockk<SkjemaService>()
     private val vedleggRepository = mockk<VedleggRepository>()
 
     val arkiveringService =
         ArkiveringService(
             integrasjonerClient,
-            søknadService,
+            skjemaService,
             vedleggRepository,
         )
 
     private val skjema =
         Skjema(
-            søknadJson = JsonWrapper(""),
+            skjemaJson = JsonWrapper(""),
             type = Stønadstype.BARNETILSYN,
             personIdent = "1",
             opprettetTid = LocalDateTime.now(),
-            søknadPdf = byteArrayOf(12),
-            søknadFrontendGitHash = "aabbccd",
+            skjemaPdf = byteArrayOf(12),
+            frontendGitHash = "aabbccd",
         )
 
     val oppdaterSkjemaSlot = slot<Skjema>()
@@ -43,9 +43,9 @@ internal class ArkiveringServiceTest {
     @BeforeEach
     fun setUp() {
         oppdaterSkjemaSlot.clear()
-        every { søknadService.hentSøknad(skjema.id) } returns skjema
+        every { skjemaService.hentSkjema(skjema.id) } returns skjema
         every { vedleggRepository.findBySøknadId(skjema.id) } returns emptyList()
-        justRun { søknadService.oppdaterSøknad(capture(oppdaterSkjemaSlot)) }
+        justRun { skjemaService.oppdaterSkjema(capture(oppdaterSkjemaSlot)) }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/arkivering/ArkiveringServiceTest.kt
@@ -44,7 +44,7 @@ internal class ArkiveringServiceTest {
     fun setUp() {
         oppdaterSkjemaSlot.clear()
         every { skjemaService.hentSkjema(skjema.id) } returns skjema
-        every { vedleggRepository.findBySøknadId(skjema.id) } returns emptyList()
+        every { vedleggRepository.findBySkjemaId(skjema.id) } returns emptyList()
         justRun { skjemaService.oppdaterSkjema(capture(oppdaterSkjemaSlot)) }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfServiceTest.kt
@@ -9,7 +9,7 @@ import no.nav.tilleggsstonader.soknad.person.PersonService
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
 import no.nav.tilleggsstonader.soknad.soknad.SøknadTestUtil.lagSøknad
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynUtil
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.læremidler.SøknadLæremidlerUtil
 import no.nav.tilleggsstonader.soknad.util.FileUtil
 import no.nav.tilleggsstonader.soknad.util.FileUtil.listFiles
@@ -34,14 +34,14 @@ class PdfServiceTest {
 
     private val pdfService = PdfService(søknadService, personService, htmlifyClient, familieDokumentClient)
 
-    val oppdaterSøknadSlot = slot<Søknad>()
+    val oppdaterSkjemaSlot = slot<Skjema>()
 
     val htmlSlot = slot<String>()
     private val pdfBytes = "pdf".toByteArray()
 
     @BeforeEach
     fun setUp() {
-        justRun { søknadService.oppdaterSøknad(capture(oppdaterSøknadSlot)) }
+        justRun { søknadService.oppdaterSøknad(capture(oppdaterSkjemaSlot)) }
         every { personService.hentNavnMedClientCredential(any()) } returns "Fornavn etternavn"
         every { familieDokumentClient.genererPdf(capture(htmlSlot)) } returns pdfBytes
     }
@@ -57,7 +57,7 @@ class PdfServiceTest {
             pdfService.lagPdf(søknad.id)
 
             assertGenerertHtml("søknad/barnetilsyn/barnetilsyn.html")
-            assertThat(oppdaterSøknadSlot.captured.søknadPdf).isEqualTo(pdfBytes)
+            assertThat(oppdaterSkjemaSlot.captured.søknadPdf).isEqualTo(pdfBytes)
         }
 
         @Test
@@ -68,7 +68,7 @@ class PdfServiceTest {
             pdfService.lagPdf(søknad.id)
 
             assertGenerertHtml("søknad/læremidler/læremidler.html")
-            assertThat(oppdaterSøknadSlot.captured.søknadPdf).isEqualTo(pdfBytes)
+            assertThat(oppdaterSkjemaSlot.captured.søknadPdf).isEqualTo(pdfBytes)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/dokument/PdfServiceTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.tilleggsstonader.kontrakter.felles.ObjectMapperProvider.objectMapper
 import no.nav.tilleggsstonader.soknad.person.PersonService
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.SøknadTestUtil.lagSøknad
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynUtil
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
@@ -27,12 +27,12 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import java.net.URI
 
 class PdfServiceTest {
-    private val søknadService = mockk<SøknadService>()
+    private val skjemaService = mockk<SkjemaService>()
     private val familieDokumentClient = mockk<FamilieDokumentClient>()
     private val htmlifyClient = lagHtmlifyClient()
     private val personService = mockk<PersonService>()
 
-    private val pdfService = PdfService(søknadService, personService, htmlifyClient, familieDokumentClient)
+    private val pdfService = PdfService(skjemaService, personService, htmlifyClient, familieDokumentClient)
 
     val oppdaterSkjemaSlot = slot<Skjema>()
 
@@ -41,7 +41,7 @@ class PdfServiceTest {
 
     @BeforeEach
     fun setUp() {
-        justRun { søknadService.oppdaterSøknad(capture(oppdaterSkjemaSlot)) }
+        justRun { skjemaService.oppdaterSkjema(capture(oppdaterSkjemaSlot)) }
         every { personService.hentNavnMedClientCredential(any()) } returns "Fornavn etternavn"
         every { familieDokumentClient.genererPdf(capture(htmlSlot)) } returns pdfBytes
     }
@@ -52,23 +52,23 @@ class PdfServiceTest {
         @Test
         fun `skal lage pdf fra barnetilsyn`() {
             val søknad = lagSøknad(SøknadBarnetilsynUtil.søknad)
-            every { søknadService.hentSøknad(søknad.id) } returns søknad
+            every { skjemaService.hentSkjema(søknad.id) } returns søknad
 
             pdfService.lagPdf(søknad.id)
 
             assertGenerertHtml("søknad/barnetilsyn/barnetilsyn.html")
-            assertThat(oppdaterSkjemaSlot.captured.søknadPdf).isEqualTo(pdfBytes)
+            assertThat(oppdaterSkjemaSlot.captured.skjemaPdf).isEqualTo(pdfBytes)
         }
 
         @Test
         fun `skal lage pdf fra læremidler`() {
             val søknad = lagSøknad(SøknadLæremidlerUtil.søknad)
-            every { søknadService.hentSøknad(søknad.id) } returns søknad
+            every { skjemaService.hentSkjema(søknad.id) } returns søknad
 
             pdfService.lagPdf(søknad.id)
 
             assertGenerertHtml("søknad/læremidler/læremidler.html")
-            assertThat(oppdaterSkjemaSlot.captured.søknadPdf).isEqualTo(pdfBytes)
+            assertThat(oppdaterSkjemaSlot.captured.skjemaPdf).isEqualTo(pdfBytes)
         }
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteControllerTest.kt
@@ -6,7 +6,7 @@ import no.nav.tilleggsstonader.soknad.IntegrationTest
 import no.nav.tilleggsstonader.soknad.infrastruktur.IntegrasjonerClient
 import no.nav.tilleggsstonader.soknad.integrasjonstest.extensions.tasks.kjørTasksKlareForProsesseringTilIngenTasksIgjen
 import no.nav.tilleggsstonader.soknad.soknad.Kvittering
-import no.nav.tilleggsstonader.soknad.soknad.domene.SøknadRepository
+import no.nav.tilleggsstonader.soknad.soknad.domene.SkjemaRepository
 import no.nav.tilleggsstonader.soknad.tokenSubject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -18,7 +18,7 @@ import java.time.LocalDate
 
 class KjørelisteControllerTest : IntegrationTest() {
     @Autowired
-    lateinit var søknadRepository: SøknadRepository
+    lateinit var skjemaRepository: SkjemaRepository
 
     @Autowired
     lateinit var integrasjonerClient: IntegrasjonerClient
@@ -37,7 +37,7 @@ class KjørelisteControllerTest : IntegrationTest() {
         kjørTasksKlareForProsesseringTilIngenTasksIgjen()
 
         val søknad =
-            with(søknadRepository.findAll()) {
+            with(skjemaRepository.findAll()) {
                 assertThat(this).hasSize(1)
                 this.single()
             }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTaskTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
 import no.nav.tilleggsstonader.soknad.soknad.SøknadService
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.varsel.DittNavKafkaProducer
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -43,8 +43,8 @@ class SendNotifikasjonTaskTest {
         }
     }
 
-    private fun opprettSøknad(type: Stønadstype): Søknad =
-        Søknad(
+    private fun opprettSøknad(type: Stønadstype): Skjema =
+        Skjema(
             id = UUID.fromString(SØKNAD_ID),
             søknadJson = JsonWrapper(""),
             type = type,

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTaskTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/prosessering/SendNotifikasjonTaskTest.kt
@@ -5,21 +5,21 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
-import no.nav.tilleggsstonader.soknad.soknad.SøknadService
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.varsel.DittNavKafkaProducer
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
 class SendNotifikasjonTaskTest {
-    private val søknadService = mockk<SøknadService>()
+    private val skjemaService = mockk<SkjemaService>()
     private val dittNavKafkaProducer = mockk<DittNavKafkaProducer>(relaxed = true)
-    private val sendNotifikasjonTask = SendNotifikasjonTask(dittNavKafkaProducer, søknadService)
+    private val sendNotifikasjonTask = SendNotifikasjonTask(dittNavKafkaProducer, skjemaService)
 
     @Test
     fun `Task blir kjørt for å sende notifikasjon om mottatt søknad om tilsyn barn`() {
         val søknad = opprettSøknad(Stønadstype.BARNETILSYN)
-        every { søknadService.hentSøknad(UUID.fromString(SØKNAD_ID)) } returns søknad
+        every { skjemaService.hentSkjema(UUID.fromString(SØKNAD_ID)) } returns søknad
         sendNotifikasjonTask.doTask(SendNotifikasjonTask.opprettTask(søknad))
         verifiserForventetKallMed("Vi har mottatt søknaden din om pass av barn.")
     }
@@ -27,14 +27,14 @@ class SendNotifikasjonTaskTest {
     @Test
     fun `Task blir kjørt for å sende notifikasjon om mottatt søknad om læremidler`() {
         val søknad = opprettSøknad(Stønadstype.LÆREMIDLER)
-        every { søknadService.hentSøknad(UUID.fromString(SØKNAD_ID)) } returns søknad
+        every { skjemaService.hentSkjema(UUID.fromString(SØKNAD_ID)) } returns søknad
         sendNotifikasjonTask.doTask(SendNotifikasjonTask.opprettTask(søknad))
         verifiserForventetKallMed("Vi har mottatt søknaden din om læremidler.")
     }
 
     private fun verifiserForventetKallMed(forventetTekst: String) {
         verify(exactly = 1) {
-            søknadService.hentSøknad(UUID.fromString(SØKNAD_ID))
+            skjemaService.hentSkjema(UUID.fromString(SØKNAD_ID))
             dittNavKafkaProducer.sendToKafka(
                 FNR,
                 forventetTekst,
@@ -46,10 +46,10 @@ class SendNotifikasjonTaskTest {
     private fun opprettSøknad(type: Stønadstype): Skjema =
         Skjema(
             id = UUID.fromString(SØKNAD_ID),
-            søknadJson = JsonWrapper(""),
+            skjemaJson = JsonWrapper(""),
             type = type,
             personIdent = FNR,
-            søknadFrontendGitHash = "aabbccd",
+            frontendGitHash = "aabbccd",
         )
 
     companion object {

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadControllerTest.kt
@@ -12,7 +12,7 @@ import no.nav.tilleggsstonader.soknad.person.PersonService
 import no.nav.tilleggsstonader.soknad.person.pdl.PdlClientCredentialClient
 import no.nav.tilleggsstonader.soknad.person.pdl.dto.AdressebeskyttelseGradering
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynUtil
-import no.nav.tilleggsstonader.soknad.soknad.domene.SøknadRepository
+import no.nav.tilleggsstonader.soknad.soknad.domene.SkjemaRepository
 import no.nav.tilleggsstonader.soknad.soknad.læremidler.SøknadLæremidlerUtil
 import no.nav.tilleggsstonader.soknad.tokenSubject
 import no.nav.tilleggsstonader.soknad.util.FileUtil
@@ -33,7 +33,7 @@ class SøknadControllerTest : IntegrationTest() {
     lateinit var personService: PersonService
 
     @Autowired
-    lateinit var søknadRepository: SøknadRepository
+    lateinit var skjemaRepository: SkjemaRepository
 
     @Autowired
     lateinit var pdlClientCredentialClient: PdlClientCredentialClient
@@ -97,13 +97,13 @@ class SøknadControllerTest : IntegrationTest() {
         stønadstype: Stønadstype,
         filnavn: String,
     ) {
-        val dbSøknad = søknadRepository.findAll().single()
-        val søknadFraDb = objectMapper.readValue<Map<String, Any>>(dbSøknad.søknadJson.json).toMutableMap()
+        val dbSøknad = skjemaRepository.findAll().single()
+        val søknadFraDb = objectMapper.readValue<Map<String, Any>>(dbSøknad.skjemaJson.json).toMutableMap()
         søknadFraDb["mottattTidspunkt"] = "2023-09-25T21:32:18.22631"
 
         assertThat(dbSøknad.personIdent).isEqualTo(tokenSubject)
         assertThat(dbSøknad.type).isEqualTo(stønadstype)
-        assertThat(dbSøknad.søknadFrontendGitHash).isEqualTo("aabbccd")
+        assertThat(dbSøknad.frontendGitHash).isEqualTo("aabbccd")
         try {
             FileUtil.skrivJsonTilFil(filnavn, søknadFraDb)
             assertThat(søknadFraDb).isEqualTo(objectMapper.readValue<Map<String, Any>>(FileUtil.readFile(filnavn)))

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadServiceTest.kt
@@ -15,7 +15,7 @@ import no.nav.tilleggsstonader.soknad.person.dto.Barn
 import no.nav.tilleggsstonader.soknad.person.dto.PersonMedBarnDto
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.BarnetilsynMapper
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynUtil
-import no.nav.tilleggsstonader.soknad.soknad.domene.SøknadRepository
+import no.nav.tilleggsstonader.soknad.soknad.domene.SkjemaRepository
 import no.nav.tilleggsstonader.soknad.soknad.domene.VedleggRepository
 import no.nav.tilleggsstonader.soknad.soknad.læremidler.LæremidlerMapper
 import org.assertj.core.api.Assertions.assertThat
@@ -29,14 +29,14 @@ import java.util.UUID
 import no.nav.tilleggsstonader.soknad.soknad.domene.Vedlegg as VedleggDomene
 
 class SøknadServiceTest {
-    private val søknadRepository = mockk<SøknadRepository>()
+    private val skjemaRepository = mockk<SkjemaRepository>()
     private val vedleggRepository = mockk<VedleggRepository>()
     private val personService = mockk<PersonService>()
     private val familieVedleggClient = mockk<FamilieVedleggClient>()
 
     private val service =
-        SøknadService(
-            søknadRepository = søknadRepository,
+        SkjemaService(
+            skjemaRepository = skjemaRepository,
             vedleggRepository = vedleggRepository,
             barnetilsynMapper = BarnetilsynMapper(),
             læremidlerMapper = LæremidlerMapper(),
@@ -53,7 +53,7 @@ class SøknadServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { søknadRepository.insert(any()) } answers { firstArg() }
+        every { skjemaRepository.insert(any()) } answers { firstArg() }
         every { person.barn } returns
             søknad.barnMedBarnepass.map {
                 Barn(
@@ -73,7 +73,7 @@ class SøknadServiceTest {
         every { person.barn } returns emptyList()
 
         assertThatThrownBy {
-            service.lagreSøknad(ident = personIdent, mottattTidspunkt = LocalDateTime.now(), søknad = søknad)
+            service.lagreSøknadTilsynBarn(ident = personIdent, mottattTidspunkt = LocalDateTime.now(), søknad = søknad)
         }.hasMessageContaining("Prøver å sende inn identer på barnen")
     }
 
@@ -86,7 +86,7 @@ class SøknadServiceTest {
 
             val dokumentasjon = lagDokumentasjonFelt(vedlegg)
             val søknadId =
-                service.lagreSøknad(
+                service.lagreSøknadTilsynBarn(
                     ident = personIdent,
                     mottattTidspunkt = LocalDateTime.now(),
                     søknad = søknad.copy(dokumentasjon = dokumentasjon),
@@ -107,7 +107,7 @@ class SøknadServiceTest {
 
             val dokumentasjon = lagDokumentasjonFelt(vedlegg)
             assertThatThrownBy {
-                service.lagreSøknad(
+                service.lagreSøknadTilsynBarn(
                     ident = personIdent,
                     mottattTidspunkt = LocalDateTime.now(),
                     søknad = søknad.copy(dokumentasjon = dokumentasjon),

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadServiceTest.kt
@@ -95,7 +95,7 @@ class SøknadServiceTest {
             val lagretVedlegg = vedleggSlot.captured.single()
             assertThat(lagretVedlegg.id).isEqualTo(vedlegg.id)
             assertThat(lagretVedlegg.type).isEqualTo(Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE)
-            assertThat(lagretVedlegg.søknadId).isEqualTo(søknadId)
+            assertThat(lagretVedlegg.skjemaId).isEqualTo(søknadId)
             assertThat(lagretVedlegg.navn).isEqualTo(vedlegg.navn)
             assertThat(lagretVedlegg.innhold).isEqualTo(byteArrayOf(12))
         }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadTestUtil.kt
@@ -18,7 +18,7 @@ import no.nav.tilleggsstonader.soknad.kjøreliste.KjørelisteMapper
 import no.nav.tilleggsstonader.soknad.person.dto.Barn
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.BarnetilsynMapper
 import no.nav.tilleggsstonader.soknad.soknad.barnetilsyn.SøknadBarnetilsynDto
-import no.nav.tilleggsstonader.soknad.soknad.domene.Søknad
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
 import no.nav.tilleggsstonader.soknad.soknad.læremidler.LæremidlerMapper
 import no.nav.tilleggsstonader.soknad.soknad.læremidler.SøknadLæremidlerDto
 import java.time.LocalDate
@@ -27,11 +27,11 @@ import java.time.LocalDateTime
 object SøknadTestUtil {
     private val mottattTidspunkt = LocalDateTime.of(2023, 1, 1, 12, 13, 0)
 
-    fun lagSøknad(kjørelisteDto: KjørelisteDto): Søknad = lagSøknad(Stønadstype.DAGLIG_REISE_TSO, lagSøknadsskjema(kjørelisteDto))
+    fun lagSøknad(kjørelisteDto: KjørelisteDto): Skjema = lagSøknad(Stønadstype.DAGLIG_REISE_TSO, lagSøknadsskjema(kjørelisteDto))
 
-    fun lagSøknad(søknadDto: SøknadBarnetilsynDto): Søknad = lagSøknad(Stønadstype.BARNETILSYN, lagSøknadsskjema(søknadDto))
+    fun lagSøknad(søknadDto: SøknadBarnetilsynDto): Skjema = lagSøknad(Stønadstype.BARNETILSYN, lagSøknadsskjema(søknadDto))
 
-    fun lagSøknad(søknadDto: SøknadLæremidlerDto): Søknad = lagSøknad(Stønadstype.LÆREMIDLER, lagSøknadsskjema(søknadDto))
+    fun lagSøknad(søknadDto: SøknadLæremidlerDto): Skjema = lagSøknad(Stønadstype.LÆREMIDLER, lagSøknadsskjema(søknadDto))
 
     fun lagSøknadsskjema(kjørelisteDto: KjørelisteDto) = KjørelisteMapper.map("25518735813", mottattTidspunkt, kjørelisteDto)
 
@@ -43,8 +43,8 @@ object SøknadTestUtil {
     fun lagSøknad(
         stønadstype: Stønadstype,
         søknadsskjema: Søknadsskjema<*>,
-    ): Søknad =
-        Søknad(
+    ): Skjema =
+        Skjema(
             søknadJson = JsonWrapper(objectMapper.writeValueAsString(søknadsskjema)),
             type = stønadstype,
             personIdent = søknadsskjema.ident,

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadTestUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/SøknadTestUtil.kt
@@ -6,9 +6,9 @@ import no.nav.tilleggsstonader.kontrakter.felles.Stønadstype
 import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.EnumFlereValgFelt
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.JaNei
 import no.nav.tilleggsstonader.kontrakter.søknad.SelectFelt
-import no.nav.tilleggsstonader.kontrakter.søknad.Søknadsskjema
 import no.nav.tilleggsstonader.kontrakter.søknad.VerdiFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.felles.TypePengestøtte
 import no.nav.tilleggsstonader.kontrakter.søknad.felles.ÅrsakOppholdUtenforNorge
@@ -42,14 +42,14 @@ object SøknadTestUtil {
 
     fun lagSøknad(
         stønadstype: Stønadstype,
-        søknadsskjema: Søknadsskjema<*>,
+        innsendtSkjema: InnsendtSkjema<*>,
     ): Skjema =
         Skjema(
-            søknadJson = JsonWrapper(objectMapper.writeValueAsString(søknadsskjema)),
+            skjemaJson = JsonWrapper(objectMapper.writeValueAsString(innsendtSkjema)),
             type = stønadstype,
-            personIdent = søknadsskjema.ident,
+            personIdent = innsendtSkjema.ident,
             opprettetTid = LocalDateTime.now(),
-            søknadFrontendGitHash = "aabbccd",
+            frontendGitHash = "aabbccd",
         )
 
     fun mapBarn(søknad: SøknadBarnetilsynDto): Map<String, Barn> =

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepositoryTest.kt
@@ -12,20 +12,20 @@ import org.springframework.dao.OptimisticLockingFailureException
 
 class SøknadRepositoryTest : IntegrationTest() {
     @Autowired
-    lateinit var søknadRepository: SøknadRepository
+    lateinit var skjemaRepository: SkjemaRepository
 
     @Test
     fun `skal kunne lagre og hente søknad`() {
         val søknad = lagreSøknad()
-        assertThat(søknadRepository.findByIdOrThrow(søknad.id)).isEqualTo(søknad)
+        assertThat(skjemaRepository.findByIdOrThrow(søknad.id)).isEqualTo(søknad)
     }
 
     @Test
     fun `skal ikke kunne lagre en søknad med samme versjon 2 ganger`() {
         val søknad = lagreSøknad()
-        søknadRepository.update(søknad)
+        skjemaRepository.update(søknad)
         assertThatThrownBy {
-            søknadRepository.update(søknad)
+            skjemaRepository.update(søknad)
         }.isInstanceOf(OptimisticLockingFailureException::class.java)
     }
 
@@ -33,32 +33,32 @@ class SøknadRepositoryTest : IntegrationTest() {
     fun `skal finne antall søknader per type`() {
         lagreSøknad()
         lagreSøknad()
-        assertThat(søknadRepository.finnAntallPerType())
+        assertThat(skjemaRepository.finnAntallPerType())
             .containsExactly(AntallPerType(Stønadstype.BARNETILSYN, 2))
     }
 
     @Test
     fun `skal kunne hente gammel søknad uten søknadFrontendGitHash`() {
         val skjema =
-            søknadRepository.insert(
+            skjemaRepository.insert(
                 Skjema(
                     type = Stønadstype.BARNETILSYN,
                     personIdent = "123",
-                    søknadJson = JsonWrapper("{}"),
-                    søknadFrontendGitHash = null,
+                    skjemaJson = JsonWrapper("{}"),
+                    frontendGitHash = null,
                 ),
             )
 
-        assertThat(søknadRepository.findByIdOrThrow(skjema.id)).isEqualTo(skjema)
+        assertThat(skjemaRepository.findByIdOrThrow(skjema.id)).isEqualTo(skjema)
     }
 
     private fun lagreSøknad() =
-        søknadRepository.insert(
+        skjemaRepository.insert(
             Skjema(
                 type = Stønadstype.BARNETILSYN,
                 personIdent = "123",
-                søknadJson = JsonWrapper("{}"),
-                søknadFrontendGitHash = "aabbccd",
+                skjemaJson = JsonWrapper("{}"),
+                frontendGitHash = "aabbccd",
             ),
         )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SøknadRepositoryTest.kt
@@ -39,9 +39,9 @@ class SøknadRepositoryTest : IntegrationTest() {
 
     @Test
     fun `skal kunne hente gammel søknad uten søknadFrontendGitHash`() {
-        val søknad =
+        val skjema =
             søknadRepository.insert(
-                Søknad(
+                Skjema(
                     type = Stønadstype.BARNETILSYN,
                     personIdent = "123",
                     søknadJson = JsonWrapper("{}"),
@@ -49,12 +49,12 @@ class SøknadRepositoryTest : IntegrationTest() {
                 ),
             )
 
-        assertThat(søknadRepository.findByIdOrThrow(søknad.id)).isEqualTo(søknad)
+        assertThat(søknadRepository.findByIdOrThrow(skjema.id)).isEqualTo(skjema)
     }
 
     private fun lagreSøknad() =
         søknadRepository.insert(
-            Søknad(
+            Skjema(
                 type = Stønadstype.BARNETILSYN,
                 personIdent = "123",
                 søknadJson = JsonWrapper("{}"),

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
@@ -43,11 +43,11 @@ class VedleggRepositoryTest : IntegrationTest() {
         }
     }
 
-    private fun lagreVedlegg(søknad: Søknad) =
+    private fun lagreVedlegg(skjema: Skjema) =
         vedleggRepository.insert(
             Vedlegg(
                 id = UUID.randomUUID(),
-                søknadId = søknad.id,
+                søknadId = skjema.id,
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
                 navn = "charlie.pdf",
                 innhold = byteArrayOf(13),
@@ -56,7 +56,7 @@ class VedleggRepositoryTest : IntegrationTest() {
 
     private fun lagreSøknad() =
         søknadRepository.insert(
-            Søknad(
+            Skjema(
                 type = Stønadstype.BARNETILSYN,
                 personIdent = "123",
                 søknadJson = JsonWrapper("{}"),

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 class VedleggRepositoryTest : IntegrationTest() {
     @Autowired
-    lateinit var søknadRepository: SøknadRepository
+    lateinit var skjemaRepository: SkjemaRepository
 
     @Autowired
     lateinit var vedleggRepository: VedleggRepository
@@ -55,12 +55,12 @@ class VedleggRepositoryTest : IntegrationTest() {
         )
 
     private fun lagreSøknad() =
-        søknadRepository.insert(
+        skjemaRepository.insert(
             Skjema(
                 type = Stønadstype.BARNETILSYN,
                 personIdent = "123",
-                søknadJson = JsonWrapper("{}"),
-                søknadFrontendGitHash = "aabbccd",
+                skjemaJson = JsonWrapper("{}"),
+                frontendGitHash = "aabbccd",
             ),
         )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/VedleggRepositoryTest.kt
@@ -35,10 +35,10 @@ class VedleggRepositoryTest : IntegrationTest() {
             val vedlegg2 = lagreVedlegg(søknad)
             val vedlegg3 = lagreVedlegg(søknad2)
 
-            assertThat(vedleggRepository.findBySøknadId(søknad.id).map { it.id })
+            assertThat(vedleggRepository.findBySkjemaId(søknad.id).map { it.id })
                 .containsExactlyInAnyOrder(vedlegg.id, vedlegg2.id)
 
-            assertThat(vedleggRepository.findBySøknadId(søknad2.id).map { it.id })
+            assertThat(vedleggRepository.findBySkjemaId(søknad2.id).map { it.id })
                 .containsExactlyInAnyOrder(vedlegg3.id)
         }
     }
@@ -47,7 +47,7 @@ class VedleggRepositoryTest : IntegrationTest() {
         vedleggRepository.insert(
             Vedlegg(
                 id = UUID.randomUUID(),
-                søknadId = skjema.id,
+                skjemaId = skjema.id,
                 type = Vedleggstype.UTGIFTER_PASS_SFO_AKS_BARNEHAGE,
                 navn = "charlie.pdf",
                 innhold = byteArrayOf(13),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Nå som vi introduserer kjørelister, blir det litt feil at koden er såpass spesifikt rettet mot "søknad"-begrepet. Endrer her begrepsbruk vekk fra søknad:
- Renamer tabell `soknad` -> `skjema`
  - erstatter også "soknad" fra kolonnenavn
- Renamer klasse `Søknad` -> `Skjema`
- Renamer masse variabler vekk fra søknad, samt enkelte klasser

`Skjema`-klassen har forstatt knytning mot `Stønadstype`. Ønsker å erstatte denne med å peke på `Skjematype` men tar det i en senere endring for at det ikke skal bli alt for mye i en PR.

Er nok også noe endring av pakkenavn som kan tas seperat også.

Sees sammen med https://github.com/navikt/tilleggsstonader-kontrakter/pull/142