### PR TITLE
✨ Legg til endepunkt for å hente ut tidligere innsendte kjørelister

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteController.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteController.kt
@@ -26,6 +26,11 @@ class KjørelisteController(
         @PathVariable reiseId: String,
     ): RammevedtakDto = kjørelisteService.hentRammevedtakForInnloggetBruker(reiseId)
 
+    @GetMapping("/{reiseId}")
+    fun hentKjørelister(
+        @PathVariable reiseId: String,
+    ): KjørelisteDto? = kjørelisteService.hentKjørelisterForReise(reiseId)
+
     @PostMapping
     fun mottaKjørelister(
         @RequestBody kjørelisteDto: KjørelisteDto,

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteMapper.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteMapper.kt
@@ -5,6 +5,7 @@ import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.Reisedag
 import no.nav.tilleggsstonader.kontrakter.søknad.UkeMedReisedager
+import no.nav.tilleggsstonader.soknad.soknad.SøknadMetadataDto
 import java.time.LocalDateTime
 
 object KjørelisteMapper {
@@ -32,5 +33,34 @@ private fun UkeMedReisedagerDto.mapTilSkjema(): UkeMedReisedager =
     UkeMedReisedager(
         ukeLabel = ukeLabel,
         spørsmål = spørsmål,
-        reisedager = reisedager.map { Reisedag(it.dato, it.harKjørt, it.parkeringsutgift) },
+        reisedager =
+            reisedager.map {
+                Reisedag(
+                    dato = it.dato,
+                    harKjørt = it.harKjørt,
+                    parkeringsutgift = it.parkeringsutgift,
+                )
+            },
+    )
+
+fun KjørelisteSkjema.tilDto(): KjørelisteDto =
+    KjørelisteDto(
+        reiseId = reiseId,
+        reisedagerPerUkeAvsnitt = reisedagerPerUkeAvsnitt.map { it.tilDto() },
+        dokumentasjon = dokumentasjon,
+        søknadMetadata = SøknadMetadataDto(søknadFrontendGitHash = null),
+    )
+
+private fun UkeMedReisedager.tilDto(): UkeMedReisedagerDto =
+    UkeMedReisedagerDto(
+        ukeLabel = ukeLabel,
+        spørsmål = spørsmål,
+        reisedager =
+            reisedager.map {
+                ReisedagDto(
+                    dato = it.dato,
+                    harKjørt = it.harKjørt,
+                    parkeringsutgift = it.parkeringsutgift,
+                )
+            },
     )

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
@@ -1,10 +1,15 @@
 package no.nav.tilleggsstonader.soknad.kjøreliste
 
+import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
+import no.nav.tilleggsstonader.kontrakter.felles.Skjematype
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
+import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
 import no.nav.tilleggsstonader.kontrakter.søknad.RammevedtakDto
 import no.nav.tilleggsstonader.libs.sikkerhet.EksternBrukerUtils
 import no.nav.tilleggsstonader.soknad.sak.DagligReisePrivatBilClient
 import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
 import org.springframework.stereotype.Service
+import tools.jackson.module.kotlin.readValue
 import java.time.LocalDateTime
 import kotlin.random.Random
 
@@ -22,6 +27,32 @@ class KjørelisteService(
                 .first { it.reiseId == reiseId }
         return rammevedtak.copy(uker = rammevedtak.uker.filter { uke -> uke.kanSendeInnKjøreliste })
     }
+
+    fun hentKjørelisterForReise(reiseId: String): KjørelisteDto? {
+        val ident = EksternBrukerUtils.hentFnrFraToken()
+        val skjemaer =
+            skjemaService.hentSkjemaerForBruker(personIdent = ident, type = Skjematype.DAGLIG_REISE_KJØRELISTE)
+
+        val kjørelister =
+            skjemaer
+                .map { jsonMapper.readValue<InnsendtSkjema<KjørelisteSkjema>>(it.skjemaJson.json).skjema }
+                .filter { it.reiseId == reiseId }
+
+        if (kjørelister.isEmpty()) return null
+
+        val sammenslåtteKjørelister = slåSammenKjørelister(reiseId = reiseId, kjørelister = kjørelister)
+        return sammenslåtteKjørelister.tilDto()
+    }
+
+    private fun slåSammenKjørelister(
+        reiseId: String,
+        kjørelister: List<KjørelisteSkjema>,
+    ): KjørelisteSkjema =
+        KjørelisteSkjema(
+            reiseId = reiseId,
+            reisedagerPerUkeAvsnitt = kjørelister.flatMap { it.reisedagerPerUkeAvsnitt },
+            dokumentasjon = kjørelister.flatMap { it.dokumentasjon },
+        )
 
     fun mottaKjøreliste(kjørelisteDto: KjørelisteDto): KjørelisteResponse {
         skjemaService.lagreKjøreliste(

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SkjemaService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/SkjemaService.kt
@@ -43,6 +43,11 @@ class SkjemaService(
 ) {
     fun hentSkjema(id: UUID): Skjema = skjemaRepository.findByIdOrThrow(id)
 
+    fun hentSkjemaerForBruker(
+        personIdent: String,
+        type: Skjematype,
+    ): List<Skjema> = skjemaRepository.findByPersonIdentAndType(personIdent, type)
+
     fun oppdaterSkjema(skjema: Skjema) {
         skjemaRepository.update(skjema)
     }

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SkjemaRepository.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/soknad/domene/SkjemaRepository.kt
@@ -21,6 +21,11 @@ interface SkjemaRepository :
     InsertUpdateRepository<Skjema> {
     @Query("SELECT type, count(*) as count FROM skjema GROUP BY type")
     fun finnAntallPerType(): List<AntallPerType>
+
+    fun findByPersonIdentAndType(
+        personIdent: String,
+        type: Skjematype,
+    ): List<Skjema>
 }
 
 data class AntallPerType(

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/SøknadApiLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/SøknadApiLocal.kt
@@ -28,6 +28,7 @@ fun main(args: Array<String>) {
             "mock-integrasjoner",
             "mock-kafka",
             "mock-rammevedtak",
+            "mock-kjoreliste",
         ).properties(mapOf("mock-oauth2-server.port" to mockOauth2ServerPort))
         .run(*args)
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/KjørelisteMockConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/infrastruktur/KjørelisteMockConfig.kt
@@ -1,0 +1,75 @@
+package no.nav.tilleggsstonader.soknad.infrastruktur
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
+import no.nav.tilleggsstonader.kontrakter.søknad.VerdiFelt
+import no.nav.tilleggsstonader.soknad.kjøreliste.KjørelisteDto
+import no.nav.tilleggsstonader.soknad.kjøreliste.KjørelisteService
+import no.nav.tilleggsstonader.soknad.kjøreliste.ReisedagDto
+import no.nav.tilleggsstonader.soknad.kjøreliste.UkeMedReisedagerDto
+import no.nav.tilleggsstonader.soknad.sak.DagligReisePrivatBilClient
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
+import no.nav.tilleggsstonader.soknad.soknad.SøknadMetadataDto
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import java.time.LocalDate
+
+@Configuration
+@Profile("mock-kjoreliste")
+class KjørelisteMockConfig {
+    @Bean
+    @Primary
+    fun kjørelisteService(): KjørelisteService {
+        val skjemaService = mockk<SkjemaService>(relaxed = true)
+        val dagligReisePrivatBilClient = mockk<DagligReisePrivatBilClient>()
+        DagligReisePrivatBilClientConfig.resetMock(dagligReisePrivatBilClient)
+
+        val service = spyk(KjørelisteService(skjemaService, dagligReisePrivatBilClient))
+        every { service.hentKjørelisterForReise("1") } returns kjørelisteDtoForReise1()
+        every { service.hentKjørelisterForReise("2") } returns null
+        return service
+    }
+
+    companion object {
+        /**
+         * Mock-data basert på rammevedtak "1" i DagligReisePrivatBilClientConfig.
+         * Uke 1 (1. jan - 5. jan 2025) har innsendtDato satt, så vi returnerer kjøreliste for den uken.
+         */
+        private fun kjørelisteDtoForReise1(): KjørelisteDto =
+            KjørelisteDto(
+                reiseId = "1",
+                reisedagerPerUkeAvsnitt =
+                    listOf(
+                        UkeMedReisedagerDto(
+                            ukeLabel = "Uke 1 (1. januar - 5. januar)",
+                            spørsmål = "Hvilke dager kjørte du?",
+                            reisedager =
+                                listOf(
+                                    reisedag(dato = LocalDate.of(2025, 1, 1), harKjørt = true, parkering = 50),
+                                    reisedag(dato = LocalDate.of(2025, 1, 2), harKjørt = true, parkering = 0),
+                                    reisedag(dato = LocalDate.of(2025, 1, 3), harKjørt = true, parkering = 30),
+                                    reisedag(dato = LocalDate.of(2025, 1, 4), harKjørt = false, parkering = null),
+                                    reisedag(dato = LocalDate.of(2025, 1, 5), harKjørt = false, parkering = null),
+                                ),
+                        ),
+                    ),
+                dokumentasjon = emptyList(),
+                søknadMetadata = SøknadMetadataDto(søknadFrontendGitHash = null),
+            )
+
+        private fun reisedag(
+            dato: LocalDate,
+            harKjørt: Boolean,
+            parkering: Number?,
+        ): ReisedagDto =
+            ReisedagDto(
+                dato = DatoFelt(label = dato.toString(), verdi = dato),
+                harKjørt = harKjørt,
+                parkeringsutgift = VerdiFelt(label = "Parkeringsutgift (kr)", verdi = parkering),
+            )
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteServiceTest.kt
@@ -5,8 +5,8 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
-import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 import no.nav.tilleggsstonader.kontrakter.felles.Skjematype
+import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
 import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
 import no.nav.tilleggsstonader.kontrakter.søknad.Dokument
 import no.nav.tilleggsstonader.kontrakter.søknad.DokumentasjonFelt
@@ -34,10 +34,11 @@ class KjørelisteServiceTest {
     private val skjemaService = mockk<SkjemaService>()
     private val dagligReisePrivatBilClient = mockk<DagligReisePrivatBilClient>()
 
-    private val service = KjørelisteService(
-        skjemaService = skjemaService,
-        dagligReisePrivatBilClient = dagligReisePrivatBilClient,
-    )
+    private val service =
+        KjørelisteService(
+            skjemaService = skjemaService,
+            dagligReisePrivatBilClient = dagligReisePrivatBilClient,
+        )
 
     private val personIdent = "12345678901"
 
@@ -114,10 +115,11 @@ class KjørelisteServiceTest {
                     personIdent = personIdent,
                     type = Skjematype.DAGLIG_REISE_KJØRELISTE,
                 )
-            } returns listOf(
-                lagSkjema(reiseId = reiseId, uker = listOf(uke1, uke2)),
-                lagSkjema(reiseId = reiseId, uker = listOf(uke3)),
-            )
+            } returns
+                listOf(
+                    lagSkjema(reiseId = reiseId, uker = listOf(uke1, uke2)),
+                    lagSkjema(reiseId = reiseId, uker = listOf(uke3)),
+                )
 
             val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
 
@@ -138,10 +140,11 @@ class KjørelisteServiceTest {
                     personIdent = personIdent,
                     type = Skjematype.DAGLIG_REISE_KJØRELISTE,
                 )
-            } returns listOf(
-                lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok1)),
-                lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok2)),
-            )
+            } returns
+                listOf(
+                    lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok1)),
+                    lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok2)),
+                )
 
             val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
 
@@ -162,10 +165,11 @@ class KjørelisteServiceTest {
                     personIdent = personIdent,
                     type = Skjematype.DAGLIG_REISE_KJØRELISTE,
                 )
-            } returns listOf(
-                lagSkjema(reiseId = reiseId, uker = listOf(ukeForRiktigReise)),
-                lagSkjema(reiseId = "annen-reise", uker = listOf(ukeForAnnenReise)),
-            )
+            } returns
+                listOf(
+                    lagSkjema(reiseId = reiseId, uker = listOf(ukeForRiktigReise)),
+                    lagSkjema(reiseId = "annen-reise", uker = listOf(ukeForAnnenReise)),
+                )
 
             val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
 
@@ -183,10 +187,11 @@ class KjørelisteServiceTest {
                     personIdent = personIdent,
                     type = Skjematype.DAGLIG_REISE_KJØRELISTE,
                 )
-            } returns listOf(
-                lagSkjema(reiseId = reiseId, frontendGitHash = "abc123"),
-                lagSkjema(reiseId = reiseId, frontendGitHash = "def456"),
-            )
+            } returns
+                listOf(
+                    lagSkjema(reiseId = reiseId, frontendGitHash = "abc123"),
+                    lagSkjema(reiseId = reiseId, frontendGitHash = "def456"),
+                )
 
             val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
 
@@ -201,17 +206,19 @@ class KjørelisteServiceTest {
         dokumentasjon: List<DokumentasjonFelt> = emptyList(),
         frontendGitHash: String? = null,
     ): Skjema {
-        val kjørelisteSkjema = KjørelisteSkjema(
-            reiseId = reiseId,
-            reisedagerPerUkeAvsnitt = uker,
-            dokumentasjon = dokumentasjon,
-        )
-        val innsendtSkjema = InnsendtSkjema(
-            ident = personIdent,
-            mottattTidspunkt = LocalDateTime.now(),
-            språk = Språkkode.NB,
-            skjema = kjørelisteSkjema,
-        )
+        val kjørelisteSkjema =
+            KjørelisteSkjema(
+                reiseId = reiseId,
+                reisedagerPerUkeAvsnitt = uker,
+                dokumentasjon = dokumentasjon,
+            )
+        val innsendtSkjema =
+            InnsendtSkjema(
+                ident = personIdent,
+                mottattTidspunkt = LocalDateTime.now(),
+                språk = Språkkode.NB,
+                skjema = kjørelisteSkjema,
+            )
         return Skjema(
             id = UUID.randomUUID(),
             type = Skjematype.DAGLIG_REISE_KJØRELISTE,
@@ -225,21 +232,23 @@ class KjørelisteServiceTest {
         UkeMedReisedager(
             ukeLabel = label,
             spørsmål = "Hvilke dager kjørte du?",
-            reisedager = listOf(
-                Reisedag(
-                    dato = DatoFelt(label = "Mandag 1. juni 2025", verdi = LocalDate.of(2025, 6, 1)),
-                    harKjørt = true,
-                    parkeringsutgift = VerdiFelt(label = "Parkeringsutgift (kr)", verdi = 50),
+            reisedager =
+                listOf(
+                    Reisedag(
+                        dato = DatoFelt(label = "Mandag 1. juni 2025", verdi = LocalDate.of(2025, 6, 1)),
+                        harKjørt = true,
+                        parkeringsutgift = VerdiFelt(label = "Parkeringsutgift (kr)", verdi = 50),
+                    ),
                 ),
-            ),
         )
 
     private fun lagDokumentasjonFelt(label: String): DokumentasjonFelt =
         DokumentasjonFelt(
             type = Vedleggstype.PARKERINGSUTGIFT,
             label = label,
-            opplastedeVedlegg = listOf(
-                Dokument(id = UUID.randomUUID(), navn = "vedlegg.pdf"),
-            ),
+            opplastedeVedlegg =
+                listOf(
+                    Dokument(id = UUID.randomUUID(), navn = "vedlegg.pdf"),
+                ),
         )
 }

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteServiceTest.kt
@@ -1,0 +1,245 @@
+package no.nav.tilleggsstonader.soknad.kjøreliste
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.tilleggsstonader.kontrakter.felles.JsonMapperProvider.jsonMapper
+import no.nav.tilleggsstonader.kontrakter.felles.Språkkode
+import no.nav.tilleggsstonader.kontrakter.felles.Skjematype
+import no.nav.tilleggsstonader.kontrakter.søknad.DatoFelt
+import no.nav.tilleggsstonader.kontrakter.søknad.Dokument
+import no.nav.tilleggsstonader.kontrakter.søknad.DokumentasjonFelt
+import no.nav.tilleggsstonader.kontrakter.søknad.InnsendtSkjema
+import no.nav.tilleggsstonader.kontrakter.søknad.KjørelisteSkjema
+import no.nav.tilleggsstonader.kontrakter.søknad.Reisedag
+import no.nav.tilleggsstonader.kontrakter.søknad.UkeMedReisedager
+import no.nav.tilleggsstonader.kontrakter.søknad.Vedleggstype
+import no.nav.tilleggsstonader.kontrakter.søknad.VerdiFelt
+import no.nav.tilleggsstonader.libs.sikkerhet.EksternBrukerUtils
+import no.nav.tilleggsstonader.soknad.infrastruktur.database.JsonWrapper
+import no.nav.tilleggsstonader.soknad.sak.DagligReisePrivatBilClient
+import no.nav.tilleggsstonader.soknad.soknad.SkjemaService
+import no.nav.tilleggsstonader.soknad.soknad.domene.Skjema
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class KjørelisteServiceTest {
+    private val skjemaService = mockk<SkjemaService>()
+    private val dagligReisePrivatBilClient = mockk<DagligReisePrivatBilClient>()
+
+    private val service = KjørelisteService(
+        skjemaService = skjemaService,
+        dagligReisePrivatBilClient = dagligReisePrivatBilClient,
+    )
+
+    private val personIdent = "12345678901"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(EksternBrukerUtils)
+        every { EksternBrukerUtils.hentFnrFraToken() } returns personIdent
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(EksternBrukerUtils)
+    }
+
+    @Nested
+    inner class HentKjørelisterForReise {
+        @Test
+        fun `skal returnere null når ingen kjørelister finnes`() {
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns emptyList()
+
+            val resultat = service.hentKjørelisterForReise(reiseId = "reise-1")
+
+            assertThat(resultat).isNull()
+        }
+
+        @Test
+        fun `skal returnere null når ingen kjørelister matcher reiseId`() {
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(lagSkjema(reiseId = "annen-reise", uker = listOf(lagUke("Uke 1"))))
+
+            val resultat = service.hentKjørelisterForReise(reiseId = "reise-1")
+
+            assertThat(resultat).isNull()
+        }
+
+        @Test
+        fun `skal returnere kjøreliste når én matcher`() {
+            val reiseId = "reise-1"
+            val uke = lagUke("Uke 1")
+
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(lagSkjema(reiseId = reiseId, uker = listOf(uke)))
+
+            val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.reiseId).isEqualTo(reiseId)
+            assertThat(resultat.reisedagerPerUkeAvsnitt).hasSize(1)
+            assertThat(resultat.reisedagerPerUkeAvsnitt[0].ukeLabel).isEqualTo("Uke 1")
+        }
+
+        @Test
+        fun `skal slå sammen reisedagerPerUkeAvsnitt fra flere kjørelister`() {
+            val reiseId = "reise-1"
+            val uke1 = lagUke("Uke 1")
+            val uke2 = lagUke("Uke 2")
+            val uke3 = lagUke("Uke 3")
+
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(
+                lagSkjema(reiseId = reiseId, uker = listOf(uke1, uke2)),
+                lagSkjema(reiseId = reiseId, uker = listOf(uke3)),
+            )
+
+            val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.reisedagerPerUkeAvsnitt).hasSize(3)
+            assertThat(resultat.reisedagerPerUkeAvsnitt.map { it.ukeLabel })
+                .containsExactly("Uke 1", "Uke 2", "Uke 3")
+        }
+
+        @Test
+        fun `skal slå sammen dokumentasjon fra flere kjørelister`() {
+            val reiseId = "reise-1"
+            val dok1 = lagDokumentasjonFelt("Kvittering 1")
+            val dok2 = lagDokumentasjonFelt("Kvittering 2")
+
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(
+                lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok1)),
+                lagSkjema(reiseId = reiseId, dokumentasjon = listOf(dok2)),
+            )
+
+            val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.dokumentasjon).hasSize(2)
+            assertThat(resultat.dokumentasjon.map { it.label })
+                .containsExactly("Kvittering 1", "Kvittering 2")
+        }
+
+        @Test
+        fun `skal filtrere bort kjørelister med annen reiseId`() {
+            val reiseId = "reise-1"
+            val ukeForRiktigReise = lagUke("Uke riktig")
+            val ukeForAnnenReise = lagUke("Uke annen")
+
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(
+                lagSkjema(reiseId = reiseId, uker = listOf(ukeForRiktigReise)),
+                lagSkjema(reiseId = "annen-reise", uker = listOf(ukeForAnnenReise)),
+            )
+
+            val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.reisedagerPerUkeAvsnitt).hasSize(1)
+            assertThat(resultat.reisedagerPerUkeAvsnitt[0].ukeLabel).isEqualTo("Uke riktig")
+        }
+
+        @Test
+        fun `søknadMetadata skal alltid ha søknadFrontendGitHash lik null`() {
+            val reiseId = "reise-1"
+
+            every {
+                skjemaService.hentSkjemaerForBruker(
+                    personIdent = personIdent,
+                    type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+                )
+            } returns listOf(
+                lagSkjema(reiseId = reiseId, frontendGitHash = "abc123"),
+                lagSkjema(reiseId = reiseId, frontendGitHash = "def456"),
+            )
+
+            val resultat = service.hentKjørelisterForReise(reiseId = reiseId)
+
+            assertThat(resultat).isNotNull
+            assertThat(resultat!!.søknadMetadata.søknadFrontendGitHash).isNull()
+        }
+    }
+
+    private fun lagSkjema(
+        reiseId: String,
+        uker: List<UkeMedReisedager> = listOf(lagUke("Uke 1")),
+        dokumentasjon: List<DokumentasjonFelt> = emptyList(),
+        frontendGitHash: String? = null,
+    ): Skjema {
+        val kjørelisteSkjema = KjørelisteSkjema(
+            reiseId = reiseId,
+            reisedagerPerUkeAvsnitt = uker,
+            dokumentasjon = dokumentasjon,
+        )
+        val innsendtSkjema = InnsendtSkjema(
+            ident = personIdent,
+            mottattTidspunkt = LocalDateTime.now(),
+            språk = Språkkode.NB,
+            skjema = kjørelisteSkjema,
+        )
+        return Skjema(
+            id = UUID.randomUUID(),
+            type = Skjematype.DAGLIG_REISE_KJØRELISTE,
+            personIdent = personIdent,
+            skjemaJson = JsonWrapper(jsonMapper.writeValueAsString(innsendtSkjema)),
+            frontendGitHash = frontendGitHash,
+        )
+    }
+
+    private fun lagUke(label: String): UkeMedReisedager =
+        UkeMedReisedager(
+            ukeLabel = label,
+            spørsmål = "Hvilke dager kjørte du?",
+            reisedager = listOf(
+                Reisedag(
+                    dato = DatoFelt(label = "Mandag 1. juni 2025", verdi = LocalDate.of(2025, 6, 1)),
+                    harKjørt = true,
+                    parkeringsutgift = VerdiFelt(label = "Parkeringsutgift (kr)", verdi = 50),
+                ),
+            ),
+        )
+
+    private fun lagDokumentasjonFelt(label: String): DokumentasjonFelt =
+        DokumentasjonFelt(
+            type = Vedleggstype.PARKERINGSUTGIFT,
+            label = label,
+            opplastedeVedlegg = listOf(
+                Dokument(id = UUID.randomUUID(), navn = "vedlegg.pdf"),
+            ),
+        )
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Første steg i å kun tillate innsending av uker tilbake i tid dersom de ikke allerede er sendt inn. Viser bruker hva hen har sendt inn tidligere og viser dette i en lesevisning. Her er det lagt til et endepunkt som henter ut tidligere innsendte kjørelsiter

https://github.com/navikt/tilleggsstonader-soknad/pull/593