### PR TITLE
Kast feil ved innsending av kjøreliste uten data

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
@@ -72,6 +72,14 @@ class KjørelisteService(
     }
 
     fun validerKjøreliste(kjørelisteDto: KjørelisteDto) {
+        val harIngenUker = kjørelisteDto.reisedagerPerUkeAvsnitt.isEmpty()
+        val harIngenVedlegg = kjørelisteDto.dokumentasjon.flatMap { it.opplastedeVedlegg }.isEmpty()
+        if (harIngenUker && harIngenVedlegg) {
+            throw SøknadValideringException(
+                "Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter",
+            )
+        }
+
         val ident = EksternBrukerUtils.hentFnrFraToken()
         val tidligereInnsendeUkeIntervaller = hentTidligereInnsendeUkeIntervaller(ident, kjørelisteDto.reiseId)
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
@@ -53,6 +53,15 @@ class ValiderKjørelisteTest {
     }
 
     @Test
+    fun `skal kaste feil når kjøreliste sendes inn uten uker og vedlegg`() {
+        val dto = lagKjørelisteDto()
+
+        assertThatThrownBy { service.validerKjøreliste(dto) }
+            .isInstanceOf(SøknadValideringException::class.java)
+            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter")
+    }
+
+    @Test
     fun `skal ikke kaste feil når det ikke finnes tidligere innsendte kjørelister`() {
         mockIngenTidligereInnsendinger()
         mockRammevedtak(lagRammevedtakUke(LocalDate.of(2025, 6, 2), kanSendeInn = true))


### PR DESCRIPTION
## Endring
Legger til validering som kaster `SøknadValideringException` når bruker sender inn en kjøreliste uten uker og uten vedlegg.

**Feilmelding:** *"Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter"*

<img width="765" height="1082" alt="image" src="https://github.com/user-attachments/assets/42d2c3bc-fc61-4773-a557-febc18647d30" />