### PR TITLE
♻️ Flytt filtrering av kanSendeInnKjøreliste til frontend

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
@@ -23,10 +23,7 @@ class KjørelisteService(
 ) {
     fun hentAlleRammevedtakForInnloggetBruker(): List<RammevedtakDto> = dagligReisePrivatBilClient.hentRammevedtakForInnloggetBruker()
 
-    fun hentRammevedtakForInnloggetBruker(reiseId: String): RammevedtakDto {
-        val rammevedtak = hentRammevedtak(reiseId)
-        return rammevedtak.copy(uker = rammevedtak.uker.filter { uke -> uke.kanSendeInnKjøreliste })
-    }
+    fun hentRammevedtakForInnloggetBruker(reiseId: String): RammevedtakDto = hentRammevedtak(reiseId)
 
     fun hentKjørelisterForReise(reiseId: String): KjørelisteDto? {
         val ident = EksternBrukerUtils.hentFnrFraToken()


### PR DESCRIPTION
Fjerner filtrering av uker i `hentRammevedtakForInnloggetBruker()` slik at alle uker returneres til frontend. Dette er for å kunne vise hvor mange uker som er klare for innsending til bruker. Frontend tar nå ansvar for å filtrere vekk uker som ikke er klare for innsending.

Validering ved innsending i `validerKjøreliste()` beholdes uendret.

Relatert PR i soknad: https://github.com/navikt/tilleggsstonader-soknad/pull/new/filtrer-kansendeinnkjoreliste-i-frontend

/cc @AStrand94 @Filipcl