### PR TITLE
Ikke tillat innsending av kjøreliste uten dager

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
@@ -70,8 +70,7 @@ class KjørelisteService(
 
     fun validerKjøreliste(kjørelisteDto: KjørelisteDto) {
         val harIngenUker = kjørelisteDto.reisedagerPerUkeAvsnitt.isEmpty()
-        val harIngenVedlegg = kjørelisteDto.dokumentasjon.flatMap { it.opplastedeVedlegg }.isEmpty()
-        if (harIngenUker && harIngenVedlegg) {
+        if (harIngenUker) {
             throw SøknadValideringException(
                 "Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter",
             )

--- a/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteService.kt
@@ -72,7 +72,7 @@ class KjørelisteService(
         val harIngenUker = kjørelisteDto.reisedagerPerUkeAvsnitt.isEmpty()
         if (harIngenUker) {
             throw SøknadValideringException(
-                "Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter",
+                "Ingen data i innsendingen, huk av for uker du har kjørt",
             )
         }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteTestdata.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/KjørelisteTestdata.kt
@@ -103,7 +103,7 @@ object KjørelisteTestdata {
         """.trimIndent()
 }
 
-private fun lagDokumentasjonFelt() =
+fun lagDokumentasjonFelt() =
     DokumentasjonFelt(
         type = Vedleggstype.PARKERINGSUTGIFT,
         label = "Vedlegglabel",

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
@@ -58,7 +58,7 @@ class ValiderKjørelisteTest {
 
         assertThatThrownBy { service.validerKjøreliste(dto) }
             .isInstanceOf(SøknadValideringException::class.java)
-            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter")
+            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt")
     }
 
     @Test
@@ -67,7 +67,7 @@ class ValiderKjørelisteTest {
 
         assertThatThrownBy { service.validerKjøreliste(dto) }
             .isInstanceOf(SøknadValideringException::class.java)
-            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter")
+            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/soknad/kjøreliste/ValiderKjørelisteTest.kt
@@ -62,6 +62,15 @@ class ValiderKjørelisteTest {
     }
 
     @Test
+    fun `skal kaste feil når kjøreliste sendes inn uten uker men med vedlegg`() {
+        val dto = lagKjørelisteDto().copy(dokumentasjon = listOf(lagDokumentasjonFelt()))
+
+        assertThatThrownBy { service.validerKjøreliste(dto) }
+            .isInstanceOf(SøknadValideringException::class.java)
+            .hasMessage("Ingen data i innsendingen, huk av for uker du har kjørt eller last opp nye dokumenter")
+    }
+
+    @Test
     fun `skal ikke kaste feil når det ikke finnes tidligere innsendte kjørelister`() {
         mockIngenTidligereInnsendinger()
         mockRammevedtak(lagRammevedtakUke(LocalDate.of(2025, 6, 2), reisedagerPerUke = 3, kanSendeInn = true))


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Er nå mulig å sende inn kjøreliste uten dager om man legger ved vedlegg. Det skal ikke være mulig, da det finnes en egen løsning for å ettersende dokumentasjon.